### PR TITLE
feat(works): enforce featured.* rule across all per-work pages

### DIFF
--- a/works/american-metabolisis/index.html
+++ b/works/american-metabolisis/index.html
@@ -62,7 +62,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/american-metabolisis/QVZjeGlweGNud0RiRHpldg.jpeg" alt="Call Me Felipe triptych - archival receipts with misspelled names" loading="eager" />
+      <img src="../../Assets/images/works/american-metabolisis/featured.png" alt="Call Me Felipe triptych - archival receipts with misspelled names" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">

--- a/works/avenir/index.html
+++ b/works/avenir/index.html
@@ -67,7 +67,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/avenir/FullSizeRender.jpg" alt="Live intervention during an Avenir activation" loading="eager" />
+      <img src="../../Assets/images/works/avenir/featured.png" alt="Live intervention during an Avenir activation" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">

--- a/works/borderline-exe/index.html
+++ b/works/borderline-exe/index.html
@@ -70,7 +70,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/borderline-exe/screenshot.png" alt="Borderline.exe opening screen with border interrogation interface" loading="eager" />
+      <img src="../../Assets/images/works/borderline-exe/featured.png" alt="Borderline.exe opening screen with border interrogation interface" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">

--- a/works/borderline/index.html
+++ b/works/borderline/index.html
@@ -67,7 +67,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/borderline/gallery-1.jpg" alt="Performer on stage during Borderline at Counterpulse, San Francisco" loading="eager" />
+      <img src="../../Assets/images/works/borderline/featured.jpg" alt="Performer on stage during Borderline at Counterpulse, San Francisco" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">

--- a/works/borrow-never-give-back/index.html
+++ b/works/borrow-never-give-back/index.html
@@ -62,7 +62,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/borrow-never-give-back/QVZmX1d4TTNkSnkyRlV6cg.jpeg" alt="Collage artwork from Borrow and Never Give Back series" loading="eager" />
+      <img src="../../Assets/images/works/borrow-never-give-back/featured.jpeg" alt="Collage artwork from Borrow and Never Give Back series" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">

--- a/works/carnation-exe/index.html
+++ b/works/carnation-exe/index.html
@@ -72,7 +72,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/carnation-exe/gallery-1.jpg" alt="Printed poems with pink carnation voting dots laid out on a table" loading="eager" />
+      <img src="../../Assets/images/works/carnation-exe/featured.jpg" alt="Printed poems with pink carnation voting dots laid out on a table" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">

--- a/works/deserve-it/index.html
+++ b/works/deserve-it/index.html
@@ -67,7 +67,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/deserve-it/gray_area_summer_artist_2024-060.jpg" alt="Halim performing Deserve It at Gray Area, San Francisco" loading="eager" />
+      <img src="../../Assets/images/works/deserve-it/featured.jpg" alt="Halim performing Deserve It at Gray Area, San Francisco" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">

--- a/works/feed-it/index.html
+++ b/works/feed-it/index.html
@@ -62,7 +62,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/feed-it/IMG_8109.JPG" alt="Performers on stage during Feed It at APE Camp in Seoul" loading="eager" />
+      <img src="../../Assets/images/works/feed-it/featured.png" alt="Performers on stage during Feed It at APE Camp in Seoul" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">

--- a/works/i-live-here/index.html
+++ b/works/i-live-here/index.html
@@ -67,7 +67,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/i-live-here/gallery-1.jpg" alt="Halim performing I Live Here at the We-Topia Gala at Counterpulse" loading="eager" />
+      <img src="../../Assets/images/works/i-live-here/featured.jpg" alt="Halim performing I Live Here at the We-Topia Gala at Counterpulse" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">

--- a/works/re-declarations/index.html
+++ b/works/re-declarations/index.html
@@ -62,7 +62,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/re-declarations/IMG_7128.JPG" alt="Physical declaration artwork from the Re/declarations exhibition" loading="eager" />
+      <img src="../../Assets/images/works/re-declarations/featured.png" alt="Physical declaration artwork from the Re/declarations exhibition" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">

--- a/works/reinforcement-exe/index.html
+++ b/works/reinforcement-exe/index.html
@@ -74,7 +74,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/reinforcement-exe/gallery-1.jpg" alt="Poet writing inside the open glass cube during Reinforcement.exe" loading="eager" />
+      <img src="../../Assets/images/works/reinforcement-exe/featured.jpg" alt="Poet writing inside the open glass cube during Reinforcement.exe" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">

--- a/works/versus-exe/index.html
+++ b/works/versus-exe/index.html
@@ -67,7 +67,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/versus-exe/gallery-1.jpg" alt="Poems with yellow voting dots spread across a wooden table at TIAT" loading="eager" />
+      <img src="../../Assets/images/works/versus-exe/featured.JPG" alt="Poems with yellow voting dots spread across a wooden table at TIAT" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">

--- a/works/we-called-us/index.html
+++ b/works/we-called-us/index.html
@@ -68,7 +68,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/we-called-us/gallery-1.png" alt="Halim performing We Called Us Poetry on stage with projected interface" loading="eager" />
+      <img src="../../Assets/images/works/we-called-us/featured.png" alt="Halim performing We Called Us Poetry on stage with projected interface" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">

--- a/works/weirder-webs/index.html
+++ b/works/weirder-webs/index.html
@@ -62,7 +62,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/weirder-webs/Whitagram-Image-4.JPG" alt="Participants building weird websites during a Weirder Webs workshop" loading="eager" />
+      <img src="../../Assets/images/works/weirder-webs/featured.png" alt="Participants building weird websites during a Weirder Webs workshop" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">

--- a/works/whomp/index.html
+++ b/works/whomp/index.html
@@ -62,7 +62,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/whomp/Screenshot-2025-10-06-at-4.39.43PM.png" alt="Whomp interface showing AI-generated poem in response to a scam text" loading="eager" />
+      <img src="../../Assets/images/works/whomp/featured.png" alt="Whomp interface showing AI-generated poem in response to a scam text" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">


### PR DESCRIPTION
## Summary

New rule: whatever image is named `featured.*` (any extension) inside `Assets/images/works/<slug>/` is **THE** featured image for that work — both as Supabase `cover_image` and as the per-work page hero.

15 per-work pages had their hero `<img src>` repointed to use the `featured.*` file in their image folder instead of a random gallery-1 / Screenshot / IMG_* fallback. Supabase `cover_image` synced for all 27 works that have a `featured.*` on disk.

Versus.exe specifically — the page hero was `gallery-1.jpg`, now `featured.JPG`.

## How to maintain

- Drop a new `featured.{png,jpg,jpeg,webp}` into `Assets/images/works/<slug>/`
- Run `node scripts/sync-featured-images.mjs` (Supabase side)
- Page side can be re-synced with the same Python pattern in this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)