### PR TITLE
fix: versus-exe featured image 404 (macOS case trap) + harden sync script

### DIFF
--- a/scripts/sync-featured-images.mjs
+++ b/scripts/sync-featured-images.mjs
@@ -30,6 +30,7 @@
  */
 
 import { readdirSync, statSync } from "fs";
+import { execSync } from "child_process";
 import { resolve, dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { createClient } from "@supabase/supabase-js";
@@ -67,12 +68,39 @@ const COVER_FALLBACK_NAMES = [
   "cover.webp",
 ];
 
-function findFeatured(folder, allowCoverFallback = false) {
-  let entries;
+// IMPORTANT: resolve the featured filename from GIT, not the filesystem.
+// macOS is case-insensitive, so readdirSync reports whatever casing the
+// file was last written with (e.g. featured.JPG) even when git tracks it
+// as featured.jpg. Vercel builds on case-sensitive Linux and serves the
+// git-tracked casing, so a featured.JPG cover_image 404s in production.
+// Consulting `git ls-files` gives us the exact name Vercel will serve.
+// Halim 2026-06-01: versus-exe hit this — DB said .JPG, prod served .jpg.
+function gitTrackedNames(folder) {
   try {
-    entries = readdirSync(folder);
+    const out = execSync(`git ls-files -- ${JSON.stringify(folder)}`, {
+      encoding: "utf8",
+    });
+    return out
+      .split("\n")
+      .map((p) => p.trim())
+      .filter(Boolean)
+      .map((p) => p.split("/").pop());
   } catch {
     return null;
+  }
+}
+
+function findFeatured(folder, allowCoverFallback = false) {
+  // Prefer git-tracked names (the production truth). Fall back to the
+  // filesystem only for files not yet committed.
+  const gitNames = gitTrackedNames(folder);
+  let entries = gitNames;
+  if (!entries || entries.length === 0) {
+    try {
+      entries = readdirSync(folder);
+    } catch {
+      return null;
+    }
   }
   const lower = new Map(entries.map((e) => [e.toLowerCase(), e]));
   for (const name of FEATURED_NAMES) {

--- a/works/versus-exe/index.html
+++ b/works/versus-exe/index.html
@@ -67,7 +67,7 @@
           </div>
         </div>
     <figure class="detail-hero">
-      <img src="../../Assets/images/works/versus-exe/featured.JPG" alt="Poems with yellow voting dots spread across a wooden table at TIAT" loading="eager" />
+      <img src="../../Assets/images/works/versus-exe/featured.jpg" alt="Poems with yellow voting dots spread across a wooden table at TIAT" loading="eager" />
     </figure>
     <div class="detail-flow">
       <div class="detail-text">


### PR DESCRIPTION
## Summary

The featured.* rule pass wrote `cover_image` + page hero as `featured.JPG` for versus-exe (macOS readdir reports on-disk casing), but git tracks `featured.jpg` and Vercel serves the git casing on case-sensitive Linux. Result: `featured.JPG` 404'd in prod, works-page card showed no image.

- Supabase `cover_image` versus-exe → `featured.jpg`
- `works/versus-exe/` hero → `featured.jpg`
- `scripts/sync-featured-images.mjs` `findFeatured()` now reads `git ls-files` (production truth) instead of `readdirSync` (leaks macOS casing). Falls back to FS only for uncommitted files.

## Test plan

- [ ] `https://www.oulipo.xyz/Assets/images/works/versus-exe/featured.jpg` → 200
- [ ] versus-exe card on /works/ shows the featured image
- [ ] versus-exe detail page hero loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)