### PR TITLE
votivepatina-stage: live multi-device performance layer

### DIFF
--- a/votive-patina/Context.md
+++ b/votive-patina/Context.md
@@ -44,6 +44,30 @@ authored against the contract, then integrated, tested, and visually verified.
 
 ## Session State
 
+- votivepatina-STAGE (live performance layer) - IN PROGRESS (PRD:
+  tasks/prd-votivepatina-stage.md). A staged multi-device layer over the piece: 3
+  surfaces (performer = main page `?stage=performer`; `/audience`; `/admin`) synced
+  live over Supabase Realtime (oulipo_main, per-session channel; offline loopback
+  transport for tests). The audience "passes the peace" (one deliberate phone motion,
+  magnitude-based + debounce + dedupe per device per station; manual button fallback);
+  crossing the per-station threshold (PASSES_PER_STATION, default = N, set in admin)
+  advances the station, reveals the next on-image translation, lights the next thread,
+  and wears the image one JPEG generation. 5 stations = the 5 prayer lines + Halim's
+  narration + directional prompts (data/stations.json). decayGen 0..5 = fully worn at
+  "Amin". ADMIN is the single authority (owns the reducer lib/perf-state.js);
+  performer + audience are renderers. Modules: lib/{perf-state,realtime,realtime-config,
+  stage,motion,performer,qr}.js + stage.css + admin/ + audience/. Purity RELAXED to
+  allow Supabase (esm.sh + \*.supabase.co only; all other remote hosts + analytics still
+  blocked; probe-verified). test:unit pinned --test-concurrency=1 (node v25 IPC flake).
+  DONE + tested: US-001 (purity+realtime), US-002 (stations), US-003 (reducer),
+  US-004 (sync), US-005 (performer + 5 threads), US-006 (audience), US-007 (motion),
+  US-008 (admin), US-009 (advance), US-011 QR + "?" controls, US-012 dry-run + docs.
+  Gates green: 53 unit, lint (3 pages), purity, 216+ e2e. REMAINING: US-010 (move the
+  MAIN-page translation onto the image as a dismissible overlay - the audience already
+  has this; the main page still shows .translation-panel below) and the SUBJECTIVE
+  US-011 remainder (Halim's "pray for us button + fonts drifted" on the main page -
+  needs his specific direction). Authority = admin deviates from the PRD's "performer
+  or admin" wording, chosen for resilience (projected performer screen can reload).
 - Status: v3 COMPLETE - built, visually verified, all gates green (29 unit,
   html-validate, purity 4/4, 192 e2e across mobile/desktop/reduced-motion), and
   committed + merged to main via PR #30 (no drift: votive-patina tree hash

--- a/votive-patina/README.md
+++ b/votive-patina/README.md
@@ -53,6 +53,12 @@ Shipped artwork: `index.html`, `styles.css`, `main.js`,
 `assets/*`. Fully client-side and offline-capable - nothing about the visitor leaves
 the device (the answered-prayer copy uses the local clipboard only).
 
+Shipped live-performance layer (votivepatina-stage): `stage.css`, `admin/`,
+`audience/`, `lib/{perf-state,realtime,stage,motion,performer,qr}.js`,
+`lib/realtime-config.js`, `data/stations.json`. This layer DOES talk to the network
+(Supabase Realtime + the QR encoder from esm.sh) and is reached only via the
+`/admin`, `/audience`, and `?stage=performer` routes - the plain art page stays offline.
+
 Not shipped: `package.json`, `tests/`, `scripts/`, `playwright.config.mjs`, and the
 **optional generative layer** (`lib/generative-expansion.js` + `experimental/`),
 which is OFF by default and never imported by the artwork. It lets the machine
@@ -71,10 +77,59 @@ call, which breaks the offline/no-surveillance principle, so it lives only in
   Swap in a licensed Arabic display face if desired.
 - The Substack link was removed - the essay now lives in the About modal.
 
+## Live performance (votivepatina-stage)
+
+A staged, multi-device layer sits on top of the piece for live shows. Three
+surfaces stay in sync over **Supabase Realtime** (broadcast + presence on a
+per-session channel); the audience (on a Zoom grid) drives it by "passing the
+peace" - one deliberate phone gesture each. The score is five stations (the five
+prayer lines, each with narration + a directional prompt, in `data/stations.json`);
+crossing a per-station threshold advances the station, reveals the next on-image
+translation, lights the next thread of light, and wears the image one generation of
+JPEG decay - so it is fully worn by "Amin".
+
+Surfaces (the session id is the `?s=` param; the audience scans the QR):
+
+- **Performer** - `/?stage=performer&s=<id>` : the main page in stage mode. A pure
+  renderer of the channel - the decaying icon, the active station (line + narration),
+  five threads of light lit per completed station, the live "{N} passed the peace"
+  readout, and the top-right `[ SHOW QR ] [ ? ]` controls.
+- **Audience** - `/audience/?s=<id>` : phone-first. Tap to join (grants iOS motion),
+  then the synced image with the station line + movement prompt as a dismissible
+  on-image overlay, and pass-the-peace by motion (or the always-present button).
+- **Admin** - `/admin/?s=<id>` : the operator console and the single **authority**
+  (it owns the reducer). Set N and the per-station threshold (default = N) live,
+  begin, reset between shows, and watch presence + the live state.
+
+Channel contract (`lib/realtime.js`): the admin broadcasts `state`
+`{ peaceCount, stationIndex, decayGen, threadsLit, threshold, started, finale, ... }`;
+the audience sends `peace` `{ deviceId, stationIndex }`. Peaces are deduped per device
+per station, in the pure reducer `lib/perf-state.js`.
+
+Run a local rehearsal: `npm run serve`, open `/admin/?s=demo`, `/?stage=performer&s=demo`,
+and `/audience/?s=demo` (set N + threshold, Begin, pass). For tests, append
+`&rt=loopback` to use an offline BroadcastChannel transport (no network).
+
+**Show-day iOS checklist**: the audience link must be HTTPS (Vercel is fine);
+"Tap to join" is the gesture that lets iOS grant `DeviceMotionEvent` permission; if a
+phone denies it, the on-screen "Pass the peace" button is the fallback.
+
+**Note on purity**: the stage layer uses Supabase Realtime, so `verify:purity` is
+relaxed to allow exactly the Supabase client (esm.sh) + `*.supabase.co`, and STILL
+blocks every other remote host and analytics. The offline art page makes no network
+call unless it is loaded in `?stage=performer`.
+
 ## Map
 
 - `DESIGN.md` - the original build contract (tokens, DOM selectors, module specs).
 - `Context.md` - living project notes (incl. the v3 redesign + bugs fixed).
+- `tasks/prd-votivepatina-stage.md` - the PRD for the live-performance layer.
+- `lib/perf-state.js` - the pure performance-state reducer (threshold + dedupe).
+- `lib/realtime.js` - the Supabase + offline-loopback transport (one channel/show).
+- `lib/stage.js` - the controller (admin authority; performer/audience renderers).
+- `lib/motion.js` - "pass the peace": deliberate-motion detection + iOS permission.
+- `lib/performer.js` - performer stage mode (renderer of the channel) + QR/about.
+- `lib/qr.js` - the QR encoder (loaded on demand for the operator surfaces).
 - `lib/decay.js` - generational JPEG-loss engine (Canvas 2D, deterministic).
 - `lib/console-prayer.js` - the bilingual scripture + single source of truth for
   every prayer string; mirrored (not duplicated) into the faux-console drawer.

--- a/votive-patina/admin/admin.js
+++ b/votive-patina/admin/admin.js
@@ -1,0 +1,97 @@
+// admin/admin.js - votivepatina-stage operator console (the authority)
+//
+// Owns the reducer via createStage({ role: "admin" }). Sets N + threshold, begins
+// and resets the show, and renders the live state + presence. Audience peaces flow
+// in over the channel and are applied here, then broadcast to every surface.
+
+import { createStage } from "../lib/stage.js";
+
+const params = new URLSearchParams(location.search);
+const sessionId = params.get("s") || "live";
+
+const els = {
+  n: document.getElementById("n-input"),
+  threshold: document.getElementById("threshold-input"),
+  begin: document.getElementById("begin-btn"),
+  reset: document.getElementById("reset-btn"),
+  presence: document.getElementById("presence-count"),
+  peaceCount: document.getElementById("peace-count"),
+  state: document.getElementById("state-readout"),
+  audienceUrl: document.getElementById("audience-url"),
+  banner: document.getElementById("transport-banner"),
+};
+
+let stage = null;
+
+// Show the audience join URL (the QR target in US-011).
+const audienceHref = new URL(
+  `../audience/?s=${encodeURIComponent(sessionId)}`,
+  location.href,
+).href;
+els.audienceUrl.textContent = audienceHref;
+
+function renderState(s) {
+  els.peaceCount.textContent = String(s.peaceCount ?? 0);
+  const phase = s.finale ? "finale" : s.started ? "active" : "preroll";
+  const activeStation =
+    s.stationIndex < s.stationCount ? s.stationIndex + 1 : "-";
+  els.state.textContent = [
+    `session     ${sessionId}`,
+    `phase       ${phase}`,
+    `station     ${activeStation} of ${s.stationCount}`,
+    `passes      ${s.passesThisStation} / ${s.threshold}`,
+    `peaceCount  ${s.peaceCount}`,
+    `decayGen    ${s.decayGen}`,
+    `threadsLit  ${s.threadsLit}`,
+  ].join("\n");
+  document.body.dataset.phase = phase;
+}
+
+function renderPresence(count) {
+  els.presence.textContent = String(count);
+}
+
+function wire() {
+  // Changing N defaults the threshold to N (operator can then lower it).
+  els.n.addEventListener("change", () => {
+    const n = clampInt(els.n.value, 1);
+    els.n.value = String(n);
+    els.threshold.value = String(n);
+    stage.setThreshold(n);
+  });
+  els.threshold.addEventListener("change", () => {
+    const t = clampInt(els.threshold.value, 1);
+    els.threshold.value = String(t);
+    stage.setThreshold(t);
+  });
+  els.begin.addEventListener("click", () => stage.begin());
+  els.reset.addEventListener("click", () => stage.reset());
+}
+
+function clampInt(v, min) {
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) && n >= min ? n : min;
+}
+
+async function boot() {
+  const initialThreshold = clampInt(els.threshold.value, 1);
+  stage = await createStage({
+    role: "admin",
+    sessionId,
+    stationCount: 5,
+    threshold: initialThreshold,
+    onState: renderState,
+    onPresence: renderPresence,
+  });
+  if (stage.mode === "loopback") {
+    els.banner.hidden = false;
+    els.banner.textContent = "offline loopback transport (test mode)";
+  }
+  wire();
+  // expose for e2e assertions
+  window.__stage = stage;
+}
+
+boot().catch((err) => {
+  els.state.textContent = "failed to join: " + (err && err.message);
+});

--- a/votive-patina/admin/index.html
+++ b/votive-patina/admin/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>Votive Patina - operator</title>
+    <link rel="stylesheet" href="../assets/fonts/fonts.css" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../stage.css" />
+  </head>
+  <body>
+    <main class="stage" id="admin">
+      <header class="station-line">
+        <span class="station-translit">Votive Patina - operator console</span>
+      </header>
+
+      <p class="stage-banner" id="transport-banner" hidden></p>
+
+      <section class="admin-grid">
+        <div class="admin-row">
+          <label for="n-input">Audience size (N)</label>
+          <input
+            id="n-input"
+            type="number"
+            min="1"
+            value="12"
+            inputmode="numeric"
+          />
+        </div>
+        <div class="admin-row">
+          <label for="threshold-input">Peaces per station</label>
+          <input
+            id="threshold-input"
+            type="number"
+            min="1"
+            value="12"
+            inputmode="numeric"
+          />
+        </div>
+        <div class="admin-row">
+          <label>Connected audience</label>
+          <span class="admin-state" id="presence-count">0</span>
+        </div>
+        <div class="admin-row" style="border: none">
+          <button class="admin-btn" id="begin-btn" type="button">Begin</button>
+          <button
+            class="admin-btn"
+            id="reset-btn"
+            type="button"
+            data-variant="danger"
+          >
+            Reset
+          </button>
+        </div>
+      </section>
+
+      <section>
+        <p class="stage-readout">
+          <b id="peace-count">0</b> people passed the peace
+        </p>
+        <pre class="admin-state" id="state-readout">joining...</pre>
+      </section>
+
+      <p class="stage-banner">
+        Audience joins at: <span id="audience-url"></span>
+      </p>
+    </main>
+
+    <script type="module" src="admin.js"></script>
+  </body>
+</html>

--- a/votive-patina/audience/audience.js
+++ b/votive-patina/audience/audience.js
@@ -1,0 +1,175 @@
+// audience/audience.js - votivepatina-stage audience phone
+//
+// Tap to join (the user gesture that lets iOS grant motion), then render the
+// synced decaying image + the active station as a dismissible on-image overlay,
+// and "pass the peace" once per station by a deliberate phone motion (or the
+// always-present manual button when motion is denied/unavailable). Dedupe per
+// device per station is enforced both locally (button disables) and by the
+// authority's reducer.
+
+import { createStage } from "../lib/stage.js";
+import { createDecayEngine } from "../lib/decay.js";
+import { requestMotionPermission, createShakeDetector } from "../lib/motion.js";
+
+const params = new URLSearchParams(location.search);
+const sessionId = params.get("s") || "live";
+const MARY_SRC = "../assets/mary-interactive.jpg";
+const MAX_STEP = 5;
+
+const els = {
+  joinGate: document.getElementById("join-gate"),
+  joinBtn: document.getElementById("join-btn"),
+  joinStatus: document.getElementById("join-status"),
+  live: document.getElementById("live"),
+  banner: document.getElementById("transport-banner"),
+  peaceCount: document.getElementById("peace-count"),
+  canvas: document.getElementById("stage-mary"),
+  overlay: document.getElementById("overlay"),
+  overlayClose: document.getElementById("overlay-close"),
+  ovTranslit: document.getElementById("ov-translit"),
+  ovArabic: document.getElementById("ov-arabic"),
+  ovEnglish: document.getElementById("ov-english"),
+  ovPrompt: document.getElementById("ov-prompt"),
+  phaseNote: document.getElementById("phase-note"),
+  peaceBtn: document.getElementById("peace-btn"),
+  flash: document.getElementById("peace-flash"),
+};
+
+let stage = null;
+let engine = null;
+let stations = [];
+let detector = null;
+let lastState = null;
+let lastStationIndex = -1;
+let passedThisStation = false;
+
+async function loadStations() {
+  const res = await fetch("../data/stations.json");
+  const data = await res.json();
+  stations = data.stations || [];
+}
+
+async function setupDecay() {
+  const img = new Image();
+  img.src = MARY_SRC;
+  if (!img.complete || img.naturalWidth === 0) {
+    await new Promise((resolve) => {
+      img.addEventListener("load", resolve, { once: true });
+      img.addEventListener("error", resolve, { once: true });
+    });
+  }
+  els.canvas.width = img.naturalWidth || 675;
+  els.canvas.height = img.naturalHeight || 1200;
+  engine = createDecayEngine({
+    canvas: els.canvas,
+    sourceImage: img,
+    maxStep: MAX_STEP,
+  });
+  engine.renderStep(0, { animate: false });
+}
+
+function renderState(s) {
+  lastState = s;
+  els.peaceCount.textContent = String(s.peaceCount ?? 0);
+  if (engine) {
+    engine.renderStep(Math.min(s.decayGen ?? 0, MAX_STEP), { animate: false });
+  }
+
+  // A station change resets the per-station dedupe and re-shows the overlay.
+  if (s.stationIndex !== lastStationIndex) {
+    lastStationIndex = s.stationIndex;
+    passedThisStation = false;
+  }
+
+  const phase = s.finale ? "finale" : s.started ? "active" : "preroll";
+  document.body.dataset.phase = phase;
+  els.live.classList.toggle("is-finale", phase === "finale");
+
+  if (phase === "active" && s.stationIndex < stations.length) {
+    showOverlay(stations[s.stationIndex]);
+    els.phaseNote.textContent = "";
+    els.peaceBtn.disabled = passedThisStation;
+  } else if (phase === "preroll") {
+    hideOverlay();
+    els.phaseNote.textContent = "Waiting for the prayer to begin.";
+    els.peaceBtn.disabled = true;
+  } else {
+    hideOverlay();
+    els.phaseNote.textContent = "Amin.";
+    els.peaceBtn.disabled = true;
+  }
+}
+
+function showOverlay(st) {
+  els.ovTranslit.textContent = st.translit;
+  els.ovArabic.textContent = st.arabic;
+  els.ovEnglish.textContent = st.english;
+  els.ovPrompt.textContent = st.prompt;
+  els.overlay.hidden = false;
+}
+
+function hideOverlay() {
+  els.overlay.hidden = true;
+}
+
+// One peace per device per station. Both the motion detector and the manual
+// button route here; the local guard plus the reducer's dedupe keep it to one.
+function doPeace() {
+  const s = lastState;
+  if (!s || !s.started || s.finale) return;
+  if (passedThisStation) return;
+  passedThisStation = true;
+  els.peaceBtn.disabled = true;
+  stage.passPeace();
+  flash("the peace is passed - سلام");
+}
+
+function flash(msg) {
+  els.flash.textContent = msg;
+  setTimeout(() => {
+    if (els.flash.textContent === msg) els.flash.textContent = "";
+  }, 2500);
+}
+
+async function join() {
+  els.joinBtn.disabled = true;
+  els.joinStatus.textContent = "joining...";
+  const perm = await requestMotionPermission();
+
+  stage = await createStage({
+    role: "audience",
+    sessionId,
+    onState: renderState,
+  });
+  window.__stage = stage;
+
+  els.joinGate.hidden = true;
+  els.live.hidden = false;
+  if (stage.mode === "loopback") {
+    els.banner.hidden = false;
+    els.banner.textContent = "offline loopback (test mode)";
+  }
+
+  if (perm === "granted") {
+    detector = createShakeDetector({ onShake: doPeace });
+    detector.start();
+  } else {
+    els.phaseNote.textContent =
+      "Motion is off - use the button to pass the peace.";
+  }
+}
+
+els.joinBtn.addEventListener("click", () =>
+  join().catch((e) => {
+    els.joinBtn.disabled = false;
+    els.joinStatus.textContent = "could not join: " + (e && e.message);
+  }),
+);
+els.peaceBtn.addEventListener("click", doPeace);
+els.overlayClose.addEventListener("click", hideOverlay);
+els.overlay.addEventListener("click", (e) => {
+  if (e.target === els.overlay) hideOverlay();
+});
+
+await loadStations();
+await setupDecay();

--- a/votive-patina/audience/index.html
+++ b/votive-patina/audience/index.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
+    <meta name="robots" content="noindex" />
+    <title>Votive Patina - pass the peace</title>
+    <link rel="stylesheet" href="../assets/fonts/fonts.css" />
+    <link rel="stylesheet" href="../styles.css" />
+    <link rel="stylesheet" href="../stage.css" />
+  </head>
+  <body>
+    <!-- entry gate: a user gesture is required to ask iOS for motion permission -->
+    <section class="join-gate" id="join-gate">
+      <h1>Votive Patina</h1>
+      <p class="join-note">
+        my mother sends me a picture of the Virgin Mary on WhatsApp
+      </p>
+      <button class="peace-btn" id="join-btn" type="button">
+        <span class="pb-en">Tap to join</span>
+        <span class="pb-ar" lang="ar" dir="rtl">انضمّ</span>
+      </button>
+      <p class="join-note" id="join-status"></p>
+    </section>
+
+    <!-- the live, synced view -->
+    <main class="stage" id="live" hidden>
+      <p class="stage-banner" id="transport-banner" hidden></p>
+
+      <p class="stage-readout">
+        <b id="peace-count">0</b> people passed the peace
+      </p>
+
+      <div class="stage-image-wrap" id="image-wrap">
+        <canvas
+          class="stage-canvas"
+          id="stage-mary"
+          width="675"
+          height="1200"
+          role="img"
+          aria-label="the Virgin Mary, wearing as the room prays"
+        ></canvas>
+        <!-- dismissible on-image overlay: the station line + the movement prompt -->
+        <div class="img-overlay" id="overlay" hidden>
+          <button
+            class="img-overlay-close"
+            id="overlay-close"
+            type="button"
+            aria-label="dismiss"
+          >
+            &times;
+          </button>
+          <div class="station-line">
+            <span class="station-translit" id="ov-translit"></span>
+            <span
+              class="station-arabic"
+              id="ov-arabic"
+              lang="ar"
+              dir="rtl"
+            ></span>
+            <span class="station-english" id="ov-english"></span>
+          </div>
+          <p class="station-prompt" id="ov-prompt"></p>
+        </div>
+      </div>
+
+      <p class="station-prompt" id="phase-note"></p>
+
+      <div style="text-align: center">
+        <button class="peace-btn" id="peace-btn" type="button" disabled>
+          <span class="pb-en">Pass the peace</span>
+          <span class="pb-ar" lang="ar" dir="rtl">سلّم</span>
+        </button>
+        <p class="peace-flash" id="peace-flash" role="status"></p>
+      </div>
+    </main>
+
+    <script type="module" src="audience.js"></script>
+  </body>
+</html>

--- a/votive-patina/data/stations.json
+++ b/votive-patina/data/stations.json
@@ -1,0 +1,54 @@
+{
+  "_note": "The live-performance score for votivepatina-stage. Five stations, each a prayer line (translit + arabic + english gloss), Halim's long-form narration (performer screen), and a directional movement prompt (audience phone). One station = one generation of JPEG decay, so the image is fully worn by 'Amin'. arabic[] mirrors lib/console-prayer.js ARABIC_LINES.",
+  "preroll": {
+    "narration": "On most days of the week I wake up to an image of the Virgin Mary in my WhatsApp. My mother sent a jpeg of the mother of the lord, edited, plastered, reimagined. And AI slop has not spared the mother of the lord. I've gotten versions of this image with Ghiblified Maries, or Mary as a Pixar child. For migrants who belong to a religious community, these images are a rosary of sorts only instead of the bead one finger passes to another, we forward pixels. And as if the mother of god knew that she now travels in a new realm, something happens every time her body is passed on from phone to phone.",
+    "cue": "Scan this QR code"
+  },
+  "stations": [
+    {
+      "index": 1,
+      "translit": "FI KHOUDNIKI KHOUZINA",
+      "arabic": "بحضنك خذينا",
+      "english": "Into your bosom take us",
+      "narration": "Embrace us. Also ingest us. Metabolize us. Your body both child-eater and church. I remember the old ladies chanting from the top of their lungs in the church my grandfather took me to every single day of summer vacation in the country side. The incense smuggling god into my lungs, which is the closest you can get to the heart through the nose. Embrace us. Mary, ingest us. Your stomach acids dissolving our defenses. Drill this faith into our bones until these masks become skin.",
+      "prompt": "Raise your phone and move your arm to the right. Pass the image to the person whose Zoom square is to your right. The image fades and pixelizes. As it is in heaven so shall it be on the Internet. With every forward, the image loses resolution you see. But not resolve, digital Mary might be a lesson in how things might melt without losing heart.",
+      "direction": "right"
+    },
+    {
+      "index": 2,
+      "translit": "WA 3AN KOULLI CHARREN 2EB3IDINA",
+      "arabic": "وعن كل شر ابعدينا",
+      "english": "And keep us away from all evil",
+      "narration": "And keep us away from all evil, which means move us. Remove our bodies from risky territory. Evil is imagined as conquest, as outsider - a snake, a criminal, a mosquito, a dictator, a dog with rabies. but never a cancer. Never the body assaulting itself. Never the teeth biting their inner cheeks, blood filling our mouths as we get drunk on ourselves. Mary, keep us away from that too. The skin inside our skins. Move us away, deeper this time, into what must be the heart.",
+      "prompt": "Let's raise our hands, waive to the left this time. Pass the image of the mother of god to the Zoom square on your left. Mary, my body is nothing if not movement, if not the gesture of stretching, a lexicon of fortified surrender.",
+      "direction": "left"
+    },
+    {
+      "index": 3,
+      "translit": "YA OUM YASSOU3",
+      "arabic": "يا أم يسوع",
+      "english": "O mother of Jesus",
+      "narration": "It must be hard to raise a child who straps his body to a rocket bound to kingdom come. Hard to birth a boy with a death drive. Love his body and wish your touch could add a growth ring to his skin, make it thick, hard enough to bend the iron nails of an empire.",
+      "prompt": "Raise your phone and move your arm to the top. Which is impossible in reality because no one levitates above you at church but is possible here. There's a story about how the pelican feeds its children its skin to the point where it dies the day it dies, the kid says, oh good i was sick of eating the same thing. The moral of the story is you're an asshole and you should call your mom.",
+      "direction": "up"
+    },
+    {
+      "index": 4,
+      "translit": "TACHAFA3I FINA",
+      "arabic": "تشفعي فينا",
+      "english": "Intercede for us",
+      "narration": "Intercede for us. Pray for us, but really pray to your son. Mary the middle woman. Mary, tell the boy we've been talking to him won't you. Won't you Mary, we've been in line for days and it doesn't let and you got your ways with him we know. Won't you, won't you Mary.",
+      "prompt": "Raise your phone and move your arm to the bottom. The ground this time.",
+      "direction": "down"
+    },
+    {
+      "index": 5,
+      "translit": "AMIN",
+      "arabic": "أمين",
+      "english": "Amen",
+      "narration": "which is Hebrew and Arabic for trustworthy. Also safe. Also the name of my grandmother's neighbor, my childhood classmate. Amin. Amen. A man kneels before a white statue whose eyes begin to water. This is not the opening for a joke nor a tale. The water is olive oil, the oil is blood with clots. The church where the man is kneeling is for sale and the Virgin knows. Her body is a shield, metal banging steel. Virgin Mary, sacred robot, Pokemon Go: Your womb is an empty ball to catch them all. Hollow Eve, now with a human inside.",
+      "prompt": "Place the phone against your heart.",
+      "direction": "heart"
+    }
+  ]
+}

--- a/votive-patina/index.html
+++ b/votive-patina/index.html
@@ -24,6 +24,9 @@
     />
     <link rel="stylesheet" href="assets/fonts/fonts.css" />
     <link rel="stylesheet" href="styles.css" />
+    <!-- stage.css adds the live-performance styles (performer stage mode); it only
+         adds new classes + strengthens [hidden], so the normal page is unchanged -->
+    <link rel="stylesheet" href="stage.css" />
   </head>
   <body>
     <!-- About: a quiet question mark, top-right -->
@@ -287,6 +290,84 @@
       </div>
       <div class="console-body"></div>
     </section>
+
+    <!-- performer stage mode: the projected screen for a live performance. Hidden
+         by default; revealed (and the normal pray UI hidden) only when the page is
+         loaded with ?stage=performer. Driven entirely by the live channel. -->
+    <div class="performer-stage" id="performer-stage" hidden>
+      <header class="perf-head">
+        <h1 class="perf-title">Votive Patina</h1>
+        <p class="stage-readout">
+          <b id="perf-count">0</b> people passed the peace
+        </p>
+        <p class="stage-banner" id="perf-banner" hidden></p>
+      </header>
+
+      <div class="perf-body">
+        <div class="perf-image-wrap">
+          <canvas
+            class="perf-canvas"
+            id="perf-canvas"
+            width="675"
+            height="1200"
+            role="img"
+            aria-label="the Virgin Mary, wearing as the room prays"
+          ></canvas>
+        </div>
+
+        <div class="perf-text" id="perf-text">
+          <div class="station-line">
+            <span class="station-translit" id="perf-translit"></span>
+            <span
+              class="station-arabic"
+              id="perf-arabic"
+              lang="ar"
+              dir="rtl"
+            ></span>
+            <span class="station-english" id="perf-english"></span>
+          </div>
+          <p class="station-narration" id="perf-narration"></p>
+        </div>
+      </div>
+
+      <div class="perf-threads" id="perf-threads" aria-hidden="true"></div>
+    </div>
+
+    <!-- access control: SHOW QR (the "?" about button sits to its right). Shown
+         only in performer stage mode. -->
+    <button
+      type="button"
+      class="stage-qr-btn"
+      id="stage-qr-btn"
+      hidden
+      aria-haspopup="dialog"
+      aria-controls="qr-overlay"
+    >
+      <span class="qr-glyph" aria-hidden="true">
+        <svg width="14" height="14" viewBox="0 0 7 7">
+          <path
+            fill="currentColor"
+            d="M0 0h3v3H0V1h1v1h1V1H1V0zM4 0h3v3H4V1h1v1h1V1H5V0zM0 4h3v3H0V5h1v1h1V5H1V4zM4 4h1v1H4zM6 4h1v1H6zM5 5h1v1H5zM4 6h1v1H4zM6 6h1v1H6z"
+          />
+        </svg>
+      </span>
+      Show QR
+    </button>
+
+    <!-- the QR overlay: a big scannable code + the join URL -->
+    <div
+      class="qr-overlay"
+      id="qr-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="join by QR"
+      hidden
+    >
+      <p class="qr-caption">Scan to join the prayer</p>
+      <div class="qr-code" id="qr-code"></div>
+      <p class="qr-url" id="qr-url"></p>
+      <button class="admin-btn" id="qr-close" type="button">close</button>
+    </div>
 
     <script type="module" src="main.js"></script>
   </body>

--- a/votive-patina/lib/motion.js
+++ b/votive-patina/lib/motion.js
@@ -1,0 +1,91 @@
+// ─────────────────────────────────────────────────────────────────────────────
+//  lib/motion.js  -  votivepatina-stage
+//
+//  "Passing the peace" on a phone: one deliberate movement = one peace. We detect
+//  it from acceleration MAGNITUDE over an adaptive baseline (gravity), debounced so
+//  a single gesture fires once and continuous shaking cannot spam it. Direction is
+//  NOT verified - the station's prompt tells the audience which way to move; the
+//  detector only asks "did a deliberate motion happen". This is robust across phone
+//  orientations, which is what a live room needs.
+//
+//  iOS 13+ requires DeviceMotionEvent.requestPermission() from a user gesture - the
+//  "Tap to join" tap. When motion is denied or unavailable, the caller shows a
+//  manual button that calls the same peace handler (the fallback path).
+//
+//  No framework, no em-dashes.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Ask for device-motion permission. MUST be called from a user gesture on iOS.
+ * @returns {Promise<"granted"|"denied"|"unsupported">}
+ */
+export async function requestMotionPermission() {
+  const DM =
+    typeof DeviceMotionEvent !== "undefined" ? DeviceMotionEvent : null;
+  if (!DM) return "unsupported";
+  if (typeof DM.requestPermission === "function") {
+    try {
+      const res = await DM.requestPermission();
+      return res === "granted" ? "granted" : "denied";
+    } catch {
+      // requestPermission throws if not called from a user gesture, or denied.
+      return "denied";
+    }
+  }
+  // Non-iOS browsers expose devicemotion without a permission prompt.
+  return "granted";
+}
+
+/**
+ * Create a deliberate-motion detector.
+ *
+ * @param {object} opts
+ * @param {() => void} opts.onShake     called once per deliberate motion
+ * @param {number} [opts.threshold=12]  m/s^2 of deviation from baseline to count
+ * @param {number} [opts.debounceMs=1100] minimum gap between counted motions
+ * @returns {{ start: () => void, stop: () => void, available: boolean }}
+ */
+export function createShakeDetector({
+  onShake,
+  threshold = 12,
+  debounceMs = 1100,
+} = {}) {
+  const available = typeof DeviceMotionEvent !== "undefined";
+  let lastFire = 0;
+  // Adaptive baseline tracks gravity (~9.81) plus slow drift, so only sharp
+  // deviations (a deliberate move) clear the threshold.
+  let baseline = 9.81;
+  let primed = false;
+
+  function handler(e) {
+    const a = e.accelerationIncludingGravity || e.acceleration;
+    if (!a) return;
+    const mag = Math.hypot(a.x || 0, a.y || 0, a.z || 0);
+    if (!primed) {
+      baseline = mag;
+      primed = true;
+      return;
+    }
+    const delta = Math.abs(mag - baseline);
+    // Slowly follow the resting orientation so re-baselining is automatic.
+    baseline = baseline * 0.9 + mag * 0.1;
+    if (delta > threshold) {
+      const now = Date.now();
+      if (now - lastFire >= debounceMs) {
+        lastFire = now;
+        if (typeof onShake === "function") onShake();
+      }
+    }
+  }
+
+  return {
+    available,
+    start() {
+      if (available)
+        addEventListener("devicemotion", handler, { passive: true });
+    },
+    stop() {
+      if (available) removeEventListener("devicemotion", handler);
+    },
+  };
+}

--- a/votive-patina/lib/perf-state.js
+++ b/votive-patina/lib/perf-state.js
@@ -1,0 +1,151 @@
+// ─────────────────────────────────────────────────────────────────────────────
+//  lib/perf-state.js  -  votivepatina-stage
+//
+//  The shared performance state machine for the live multi-device build, kept as
+//  a PURE module so the threshold + dedupe logic is deterministic and testable
+//  with no transport, no DOM, no Supabase. One authoritative host runs this; the
+//  resulting state is what gets broadcast to every surface (performer, audience,
+//  admin) over lib/realtime.js.
+//
+//  The score has `stationCount` stations (5: the five prayer lines). The audience
+//  "passes the peace" - one deliberate phone gesture = one peace. When the peaces
+//  for the active station reach `threshold` (PASSES_PER_STATION), the station
+//  advances by one and the image wears one generation of JPEG decay. So:
+//
+//    stationIndex = number of stations completed   (0 = pristine .. stationCount = finale)
+//    decayGen     = stationIndex                   (drives renderStep; 0..stationCount)
+//    threadsLit   = stationIndex                   (one thread of light per completed station)
+//
+//  The station currently being prayed is `stations[stationIndex]` while
+//  stationIndex < stationCount; at stationIndex === stationCount the piece is in
+//  its finale (fully worn, every thread lit).
+//
+//  Dedupe is per device per station: a given deviceId may add at most one peace to
+//  the active station, and a peace tagged for a different station is ignored
+//  (a laggy phone cannot contribute to the wrong station). `passedDevices` is the
+//  set of devices that have passed the ACTIVE station; it clears on every advance.
+//
+//  Every function is pure: it returns a NEW state object and never mutates its
+//  input. State is plain JSON (arrays, not Sets) so it serialises straight onto a
+//  realtime broadcast. No em-dashes, no framework.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_STATION_COUNT = 5;
+const DEFAULT_THRESHOLD = 1;
+
+/**
+ * Build the initial performance state.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.stationCount=5]  total stations in the score
+ * @param {number} [opts.threshold=1]     peaces needed to advance one station (PASSES_PER_STATION)
+ * @returns {object} a fresh state
+ */
+export function createPerfState({
+  stationCount = DEFAULT_STATION_COUNT,
+  threshold = DEFAULT_THRESHOLD,
+} = {}) {
+  return {
+    stationCount,
+    threshold: clampThreshold(threshold),
+    peaceCount: 0,
+    stationIndex: 0,
+    decayGen: 0,
+    threadsLit: 0,
+    passesThisStation: 0,
+    finale: false,
+    passedDevices: [],
+  };
+}
+
+/**
+ * Apply one "passed the peace" event from a device.
+ *
+ * No-op (returns an equal-valued new state) when:
+ *   - the piece is already at its finale,
+ *   - the peace is tagged for a station other than the active one (stale), or
+ *   - this device has already passed the active station (dedupe per device per station).
+ *
+ * Otherwise increments peaceCount + passesThisStation and records the device. If
+ * that reaches the threshold, the station advances by exactly one and decayGen +
+ * threadsLit step with it; reaching stationCount sets `finale`.
+ *
+ * @param {object} state
+ * @param {{deviceId: string, stationIndex: number}} peace
+ * @returns {object} the next state (new object)
+ */
+export function applyPeace(state, { deviceId, stationIndex } = {}) {
+  // Finale: nothing more to count.
+  if (state.finale || state.stationIndex >= state.stationCount) return state;
+
+  // The peace must be for the station we are actually on.
+  if (typeof stationIndex === "number" && stationIndex !== state.stationIndex) {
+    return state;
+  }
+
+  // Dedupe: one peace per device per active station.
+  if (!deviceId || state.passedDevices.includes(deviceId)) return state;
+
+  const passedDevices = [...state.passedDevices, deviceId];
+  const peaceCount = state.peaceCount + 1;
+  const passesThisStation = state.passesThisStation + 1;
+
+  // Not yet at threshold: just record the peace.
+  if (passesThisStation < state.threshold) {
+    return { ...state, peaceCount, passesThisStation, passedDevices };
+  }
+
+  // Threshold reached: advance exactly one station; the image wears a generation.
+  const nextStation = state.stationIndex + 1;
+  return {
+    ...state,
+    peaceCount,
+    stationIndex: nextStation,
+    decayGen: nextStation,
+    threadsLit: nextStation,
+    passesThisStation: 0,
+    finale: nextStation >= state.stationCount,
+    passedDevices: [],
+  };
+}
+
+/**
+ * Set the per-station threshold live (admin). Takes effect for the next
+ * evaluation; never retroactively advances. Clamped to >= 1.
+ *
+ * @param {object} state
+ * @param {number} threshold
+ * @returns {object}
+ */
+export function setThreshold(state, threshold) {
+  return { ...state, threshold: clampThreshold(threshold) };
+}
+
+/**
+ * Reset to the start of a performance, preserving the station count + threshold.
+ * Used between performances.
+ *
+ * @param {object} state
+ * @returns {object}
+ */
+export function reset(state) {
+  return createPerfState({
+    stationCount: state.stationCount,
+    threshold: state.threshold,
+  });
+}
+
+/**
+ * The index of the station currently being prayed, or null at the finale.
+ * @param {object} state
+ * @returns {number|null}
+ */
+export function activeStationIndex(state) {
+  return state.stationIndex < state.stationCount ? state.stationIndex : null;
+}
+
+// A threshold below 1 would advance on zero peaces; keep it sane.
+function clampThreshold(n) {
+  const v = Math.floor(Number(n));
+  return Number.isFinite(v) && v >= 1 ? v : 1;
+}

--- a/votive-patina/lib/performer.js
+++ b/votive-patina/lib/performer.js
@@ -1,0 +1,193 @@
+// ─────────────────────────────────────────────────────────────────────────────
+//  lib/performer.js  -  votivepatina-stage
+//
+//  Performer stage mode: the existing main page, projected for a live show. It is
+//  a pure renderer of the channel state - it never owns the reducer and never
+//  sends peaces. It reuses the generational-JPEG decay engine on its own canvas,
+//  shows the active station (line + the long narration), lights one thread of
+//  light per completed station, and carries the live "{N} people passed the peace"
+//  readout.
+//
+//  Loaded ONLY when the page is opened with ?stage=performer (main.js dynamically
+//  imports this), so normal visitors never pull in the realtime layer. No
+//  em-dashes, no framework.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { createStage } from "./stage.js";
+import { createDecayEngine } from "./decay.js";
+import { setupAbout } from "./about.js";
+import { qrSvg } from "./qr.js";
+
+export async function setupPerformer({
+  sessionId = "live",
+  stationCount = 5,
+} = {}) {
+  document.body.dataset.stage = "performer";
+  const stageEl = document.getElementById("performer-stage");
+  if (stageEl) stageEl.hidden = false;
+
+  const els = {
+    count: document.getElementById("perf-count"),
+    banner: document.getElementById("perf-banner"),
+    canvas: document.getElementById("perf-canvas"),
+    translit: document.getElementById("perf-translit"),
+    arabic: document.getElementById("perf-arabic"),
+    english: document.getElementById("perf-english"),
+    narration: document.getElementById("perf-narration"),
+    threads: document.getElementById("perf-threads"),
+  };
+
+  // ── the score ──
+  const data = await (await fetch("./data/stations.json")).json();
+  const stations = data.stations || [];
+  const preroll = data.preroll || null;
+
+  // ── the decaying image (reuse the engine) ──
+  const img = new Image();
+  img.src = "./assets/mary-interactive.jpg";
+  if (!img.complete || img.naturalWidth === 0) {
+    await new Promise((resolve) => {
+      img.addEventListener("load", resolve, { once: true });
+      img.addEventListener("error", resolve, { once: true });
+    });
+  }
+  els.canvas.width = img.naturalWidth || 675;
+  els.canvas.height = img.naturalHeight || 1200;
+  const engine = createDecayEngine({
+    canvas: els.canvas,
+    sourceImage: img,
+    maxStep: stationCount,
+  });
+  engine.renderStep(0, { animate: false });
+
+  // ── the threads of light ──
+  buildThreads(els.threads, stationCount);
+
+  // ── join + render ──
+  const stage = await createStage({
+    role: "performer",
+    sessionId,
+    stationCount,
+    onState: render,
+  });
+  window.__stage = stage;
+  if (stage.mode === "loopback" && els.banner) {
+    els.banner.hidden = false;
+    els.banner.textContent = "offline loopback (test mode)";
+  }
+
+  setupAccessControls(sessionId);
+
+  function render(s) {
+    if (els.count) els.count.textContent = String(s.peaceCount ?? 0);
+    engine.renderStep(Math.min(s.decayGen ?? 0, stationCount), {
+      animate: false,
+    });
+    lightThreads(els.threads, s.threadsLit ?? 0);
+
+    const phase = s.finale ? "finale" : s.started ? "active" : "preroll";
+    document.body.dataset.phase = phase;
+    if (stageEl) stageEl.classList.toggle("is-finale", phase === "finale");
+
+    if (phase === "active" && s.stationIndex < stations.length) {
+      showStation(stations[s.stationIndex]);
+    } else if (phase === "finale" && stations.length) {
+      showStation(stations[stations.length - 1]);
+    } else {
+      // preroll: the opening narration, no station line yet
+      setText(els.translit, "");
+      setText(els.arabic, "");
+      setText(els.english, "");
+      setText(els.narration, preroll ? preroll.narration : "");
+    }
+  }
+
+  function showStation(st) {
+    setText(els.translit, st.translit);
+    setText(els.arabic, st.arabic);
+    setText(els.english, st.english);
+    setText(els.narration, st.narration);
+  }
+
+  return stage;
+}
+
+// Top-right access controls: SHOW QR (so the audience can join) + the "?" about
+// modal restyled to sit to its right. The QR is generated on demand (the
+// performer is online); if the encoder fails to load, the join URL is the
+// fallback the operator can read out.
+function setupAccessControls(sessionId) {
+  try {
+    setupAbout();
+  } catch {
+    /* the about modal is optional */
+  }
+
+  const qrBtn = document.getElementById("stage-qr-btn");
+  const overlay = document.getElementById("qr-overlay");
+  const codeEl = document.getElementById("qr-code");
+  const urlEl = document.getElementById("qr-url");
+  const closeBtn = document.getElementById("qr-close");
+  if (!qrBtn || !overlay) return;
+
+  const audienceUrl = new URL(
+    `audience/?s=${encodeURIComponent(sessionId)}`,
+    location.href,
+  ).href;
+  if (urlEl) urlEl.textContent = audienceUrl;
+  qrBtn.hidden = false;
+
+  let built = false;
+  async function openQr() {
+    overlay.hidden = false;
+    if (built) return;
+    built = true;
+    try {
+      if (codeEl) codeEl.innerHTML = await qrSvg(audienceUrl, { cellSize: 6 });
+    } catch {
+      // offline / encoder unavailable: the URL above is the fallback.
+      if (codeEl) codeEl.innerHTML = "";
+    }
+  }
+  function closeQr() {
+    overlay.hidden = true;
+  }
+
+  qrBtn.addEventListener("click", openQr);
+  if (closeBtn) closeBtn.addEventListener("click", closeQr);
+  overlay.addEventListener("click", (e) => {
+    if (e.target === overlay) closeQr();
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && !overlay.hidden) closeQr();
+  });
+}
+
+function setText(el, text) {
+  if (el) el.textContent = text;
+}
+
+function buildThreads(container, n) {
+  if (!container) return;
+  container.innerHTML = "";
+  for (let i = 0; i < n; i++) {
+    const thread = document.createElement("div");
+    thread.className = "perf-thread";
+    thread.dataset.lit = "false";
+    const line = document.createElement("div");
+    line.className = "perf-thread-line";
+    const num = document.createElement("span");
+    num.className = "perf-thread-num";
+    num.textContent = String(i + 1).padStart(2, "0");
+    thread.appendChild(line);
+    thread.appendChild(num);
+    container.appendChild(thread);
+  }
+}
+
+function lightThreads(container, lit) {
+  if (!container) return;
+  Array.from(container.children).forEach((thread, i) => {
+    thread.dataset.lit = i < lit ? "true" : "false";
+  });
+}

--- a/votive-patina/lib/qr.js
+++ b/votive-patina/lib/qr.js
@@ -1,0 +1,38 @@
+// ─────────────────────────────────────────────────────────────────────────────
+//  lib/qr.js  -  votivepatina-stage
+//
+//  QR rendering for the operator-facing surfaces (performer + admin), so the
+//  audience can scan their way in. Those surfaces are already online (Supabase),
+//  so we load a tiny QR encoder from esm.sh (the one allowed CDN) on demand and
+//  return an SVG string. The audience never generates a QR - it scans one - so the
+//  offline audience path stays dependency-free.
+//
+//  No bundler, no em-dashes.
+// ─────────────────────────────────────────────────────────────────────────────
+
+let _qrPromise = null;
+
+function loadQr() {
+  if (!_qrPromise) {
+    _qrPromise = import("https://esm.sh/qrcode-generator@1.4.4");
+  }
+  return _qrPromise;
+}
+
+/**
+ * Build a scannable QR code for `text` as an inline SVG string.
+ * @param {string} text  the URL to encode
+ * @param {object} [opts]
+ * @param {number} [opts.cellSize=5]
+ * @param {number} [opts.margin=2]
+ * @returns {Promise<string>} an <svg> tag
+ */
+export async function qrSvg(text, { cellSize = 5, margin = 2 } = {}) {
+  const mod = await loadQr();
+  const qrcode = mod.default || mod;
+  // type 0 = auto-fit the smallest version that holds the data; M = ~15% recovery.
+  const qr = qrcode(0, "M");
+  qr.addData(String(text));
+  qr.make();
+  return qr.createSvgTag({ cellSize, margin, scalable: true });
+}

--- a/votive-patina/lib/realtime-config.js
+++ b/votive-patina/lib/realtime-config.js
@@ -1,0 +1,24 @@
+// ─────────────────────────────────────────────────────────────────────────────
+//  lib/realtime-config.js  -  votivepatina-stage
+//
+//  Supabase Realtime connection config for the live performance layer. This is
+//  the ONE place the project URL + public key live.
+//
+//  IMPORTANT: the key below is the PUBLISHABLE (anon) key for the oulipo_main
+//  project. It is designed to ship in client code - it only grants what Row Level
+//  Security and the Realtime policies allow, and it can be rotated independently.
+//  A service/secret key must NEVER appear in the shipped artwork.
+//
+//  The stage layer uses Realtime broadcast + presence on an ephemeral channel
+//  (no table writes for the core flow), so the public key is sufficient.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// oulipo_main project (ref smytgqkgomsfyurskpcl).
+export const SUPABASE_URL = "https://smytgqkgomsfyurskpcl.supabase.co";
+
+// Publishable anon key (public, RLS-gated). No service key, ever.
+export const SUPABASE_KEY = "sb_publishable_m509hZmnUb8NZRG94irXqA_AViI-8qf";
+
+// Channel namespace; the per-show session id is appended at join time, so each
+// performance is isolated on its own channel: `${CHANNEL_PREFIX}:${sessionId}`.
+export const CHANNEL_PREFIX = "votivepatina-stage";

--- a/votive-patina/lib/realtime.js
+++ b/votive-patina/lib/realtime.js
@@ -1,0 +1,244 @@
+// ─────────────────────────────────────────────────────────────────────────────
+//  lib/realtime.js  -  votivepatina-stage
+//
+//  The cross-device transport for the live performance. One channel per show
+//  carries two kinds of message and a presence roster:
+//
+//    state  - the authoritative performance state, broadcast by the single host
+//             (performer, or admin if there is no performer). Every surface
+//             renders from it. See lib/perf-state.js.
+//    peace  - "I passed the peace", sent by an audience phone. The host applies
+//             it to the reducer and broadcasts the new state.
+//    presence - who is connected; the admin counts audience devices against N.
+//
+//  Two transports behind one interface:
+//
+//    "supabase" (default, live shows): Supabase Realtime broadcast + presence.
+//               The client is loaded as an ESM module from a CDN at runtime - the
+//               ONE allowed remote import in the codebase (see verify-purity).
+//    "loopback" (offline tests): a BroadcastChannel that bridges pages in the
+//               same browser context, so the 2-client sync test runs with no
+//               network. Force it with `?rt=loopback` or window.__VOTIVE_LOOPBACK__.
+//
+//  joinSession() resolves to a handle:
+//    { deviceId, mode, broadcast(state), onState(cb), sendPeace(payload),
+//      onPeace(cb), onPresence(cb), leave() }
+//  Each on*(cb) returns an unsubscribe function.
+//
+//  No bundler, no em-dashes.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import {
+  SUPABASE_URL,
+  SUPABASE_KEY,
+  CHANNEL_PREFIX,
+} from "./realtime-config.js";
+
+// The single allowed remote import. Kept as a literal so the purity checker can
+// see it and allowlist the host explicitly (it does, for esm.sh only).
+const SUPABASE_ESM = "https://esm.sh/@supabase/supabase-js@2";
+
+/**
+ * Join a performance session.
+ *
+ * @param {object} opts
+ * @param {string} opts.sessionId            the per-show id (channel suffix)
+ * @param {"performer"|"audience"|"admin"} [opts.role="audience"]
+ * @param {string} [opts.deviceId]           stable id for dedupe/presence (generated if absent)
+ * @param {"supabase"|"loopback"} [opts.transport]  force a transport (else auto)
+ * @returns {Promise<object>} the session handle
+ */
+export async function joinSession({
+  sessionId,
+  role = "audience",
+  deviceId,
+  transport,
+} = {}) {
+  const id = deviceId || randomId();
+  const mode = transport || pickTransport();
+  const impl =
+    mode === "loopback"
+      ? loopbackTransport({ sessionId, role, deviceId: id })
+      : await supabaseTransport({ sessionId, role, deviceId: id });
+  return { deviceId: id, mode, ...impl };
+}
+
+// Auto-pick: loopback only when explicitly requested (offline tests); else live.
+function pickTransport() {
+  try {
+    const p = new URLSearchParams(location.search);
+    if (p.get("rt") === "loopback") return "loopback";
+  } catch {
+    /* no location (non-browser) */
+  }
+  if (typeof globalThis !== "undefined" && globalThis.__VOTIVE_LOOPBACK__) {
+    return "loopback";
+  }
+  return "supabase";
+}
+
+// ── Supabase transport (live) ────────────────────────────────────────────────
+
+async function supabaseTransport({ sessionId, role, deviceId }) {
+  const { createClient } =
+    await import("https://esm.sh/@supabase/supabase-js@2");
+  const client = createClient(SUPABASE_URL, SUPABASE_KEY, {
+    realtime: { params: { eventsPerSecond: 20 } },
+  });
+  const channelName = `${CHANNEL_PREFIX}:${sessionId}`;
+  const channel = client.channel(channelName, {
+    config: { broadcast: { self: false }, presence: { key: deviceId } },
+  });
+
+  const stateCbs = new Set();
+  const peaceCbs = new Set();
+  const presenceCbs = new Set();
+
+  channel.on("broadcast", { event: "state" }, ({ payload }) =>
+    stateCbs.forEach((cb) => cb(payload)),
+  );
+  channel.on("broadcast", { event: "peace" }, ({ payload }) =>
+    peaceCbs.forEach((cb) => cb(payload)),
+  );
+  channel.on("presence", { event: "sync" }, () => {
+    const count = countAudience(channel.presenceState());
+    presenceCbs.forEach((cb) => cb(count, channel.presenceState()));
+  });
+
+  await new Promise((resolve) => {
+    channel.subscribe((status) => {
+      if (status === "SUBSCRIBED") {
+        channel.track({ role, deviceId, t: Date.now() });
+        resolve();
+      }
+    });
+  });
+
+  return {
+    broadcast: (state) =>
+      channel.send({ type: "broadcast", event: "state", payload: state }),
+    sendPeace: (payload) =>
+      channel.send({ type: "broadcast", event: "peace", payload }),
+    onState: (cb) => addCb(stateCbs, cb),
+    onPeace: (cb) => addCb(peaceCbs, cb),
+    onPresence: (cb) => addCb(presenceCbs, cb),
+    leave: () => {
+      try {
+        channel.untrack();
+      } catch {
+        /* ignore */
+      }
+      client.removeChannel(channel);
+    },
+  };
+}
+
+// presenceState() is keyed by presence key; each value is an array of metas.
+function countAudience(state) {
+  let n = 0;
+  for (const key of Object.keys(state || {})) {
+    const metas = state[key];
+    if (Array.isArray(metas) && metas.some((m) => m && m.role === "audience")) {
+      n += 1;
+    }
+  }
+  return n;
+}
+
+// ── Loopback transport (offline: BroadcastChannel across pages) ───────────────
+
+function loopbackTransport({ sessionId, role, deviceId }) {
+  const bc = new BroadcastChannel(`${CHANNEL_PREFIX}:${sessionId}`);
+  const stateCbs = new Set();
+  const peaceCbs = new Set();
+  const presenceCbs = new Set();
+  const peers = new Map(); // deviceId -> { role }
+  peers.set(deviceId, { role });
+
+  const emitPresence = () => {
+    let n = 0;
+    for (const v of peers.values()) if (v.role === "audience") n += 1;
+    const roster = Object.fromEntries(peers);
+    presenceCbs.forEach((cb) => cb(n, roster));
+  };
+
+  bc.onmessage = (e) => {
+    const msg = e.data;
+    if (!msg || typeof msg !== "object") return;
+    switch (msg.kind) {
+      case "state":
+        stateCbs.forEach((cb) => cb(msg.payload));
+        break;
+      case "peace":
+        peaceCbs.forEach((cb) => cb(msg.payload));
+        break;
+      case "hello":
+        // a peer announced itself: record it and announce back so it sees us.
+        peers.set(msg.deviceId, { role: msg.role });
+        bc.postMessage({ kind: "here", deviceId, role });
+        emitPresence();
+        break;
+      case "here":
+        peers.set(msg.deviceId, { role: msg.role });
+        emitPresence();
+        break;
+      case "bye":
+        peers.delete(msg.deviceId);
+        emitPresence();
+        break;
+      default:
+        break;
+    }
+  };
+
+  // Announce ourselves and ask the room to announce back.
+  bc.postMessage({ kind: "hello", deviceId, role });
+  emitPresence();
+
+  const sayBye = () => {
+    try {
+      bc.postMessage({ kind: "bye", deviceId });
+    } catch {
+      /* channel may be closed */
+    }
+  };
+  try {
+    addEventListener("pagehide", sayBye);
+  } catch {
+    /* non-browser */
+  }
+
+  return {
+    broadcast: (state) => bc.postMessage({ kind: "state", payload: state }),
+    sendPeace: (payload) => bc.postMessage({ kind: "peace", payload }),
+    onState: (cb) => addCb(stateCbs, cb),
+    onPeace: (cb) => addCb(peaceCbs, cb),
+    onPresence: (cb) => addCb(presenceCbs, cb),
+    leave: () => {
+      sayBye();
+      try {
+        bc.close();
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function addCb(set, cb) {
+  set.add(cb);
+  return () => set.delete(cb);
+}
+
+function randomId() {
+  try {
+    if (globalThis.crypto && globalThis.crypto.randomUUID) {
+      return globalThis.crypto.randomUUID();
+    }
+  } catch {
+    /* fall through */
+  }
+  return "d-" + Math.random().toString(36).slice(2) + Date.now().toString(36);
+}

--- a/votive-patina/lib/stage.js
+++ b/votive-patina/lib/stage.js
@@ -1,0 +1,136 @@
+// ─────────────────────────────────────────────────────────────────────────────
+//  lib/stage.js  -  votivepatina-stage
+//
+//  The controller that ties the pure reducer (perf-state.js) to the transport
+//  (realtime.js) for all three surfaces. One authority owns the reducer; the
+//  others render from its broadcasts.
+//
+//  Authority model: the ADMIN is the single source of truth. It owns the reducer
+//  and is the only surface that sets N / threshold / begin / reset and that
+//  applies incoming peaces, then broadcasts the resulting state. The performer
+//  and audience are pure renderers (the audience additionally SENDS peaces). This
+//  keeps the projected performer screen disposable - it can reload mid-show and
+//  re-sync from the next broadcast - and puts every authoritative action on the
+//  operator's own console. Late joiners are caught up because the admin
+//  re-broadcasts whenever the presence roster changes.
+//
+//  createStage({ role, sessionId, ... }) -> a handle:
+//    { deviceId, mode, role, getState(),
+//      passPeace(),                 // audience: "I passed the peace"
+//      setThreshold(n), begin(), reset(),   // admin only (no-ops elsewhere)
+//      leave() }
+//  and calls onState(state) / onPresence(count, roster) as things change.
+//
+//  The broadcast state is the reducer state plus `started` (preroll vs active),
+//  which the admin flips with begin(). No framework, no em-dashes.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { joinSession } from "./realtime.js";
+import {
+  createPerfState,
+  applyPeace,
+  setThreshold as reduceThreshold,
+  reset as reduceReset,
+} from "./perf-state.js";
+
+/**
+ * @param {object} opts
+ * @param {"performer"|"audience"|"admin"} opts.role
+ * @param {string} opts.sessionId
+ * @param {number} [opts.stationCount=5]
+ * @param {number} [opts.threshold=1]   initial PASSES_PER_STATION (admin)
+ * @param {"supabase"|"loopback"} [opts.transport]
+ * @param {(state:object)=>void} [opts.onState]
+ * @param {(count:number, roster:object)=>void} [opts.onPresence]
+ * @returns {Promise<object>} the stage handle
+ */
+export async function createStage({
+  role,
+  sessionId,
+  stationCount = 5,
+  threshold = 1,
+  transport,
+  onState,
+  onPresence,
+} = {}) {
+  const session = await joinSession({ sessionId, role, transport });
+  const isAuthority = role === "admin";
+
+  let state = createPerfState({ stationCount, threshold });
+  let started = false; // preroll until the admin begins
+  let last = view();
+
+  function view() {
+    return { ...state, started };
+  }
+
+  function emit(v) {
+    last = v;
+    if (onState) onState(v);
+  }
+
+  // Authority: render locally AND broadcast to the room.
+  function pushAuthoritative() {
+    const v = view();
+    emit(v);
+    session.broadcast(v);
+  }
+
+  if (isAuthority) {
+    session.onPeace((p) => {
+      // Peaces only count once the show has begun and before the finale.
+      if (!started || state.finale) return;
+      const next = applyPeace(state, p);
+      if (next !== state) {
+        state = next;
+        pushAuthoritative();
+      }
+    });
+    session.onPresence((count, roster) => {
+      if (onPresence) onPresence(count, roster);
+      // A new device joined (or left): rebroadcast so late joiners sync.
+      pushAuthoritative();
+    });
+    // Initial broadcast so any already-present surface gets the starting state.
+    pushAuthoritative();
+  } else {
+    session.onState((s) => emit(s));
+    if (onPresence) {
+      session.onPresence((count, roster) => onPresence(count, roster));
+    }
+  }
+
+  return {
+    deviceId: session.deviceId,
+    mode: session.mode,
+    role,
+    getState: () => last,
+
+    // Audience: pass the peace for the station we currently believe is active.
+    passPeace: () =>
+      session.sendPeace({
+        deviceId: session.deviceId,
+        stationIndex: last.stationIndex ?? 0,
+      }),
+
+    // Admin authority controls (no-ops on other roles).
+    setThreshold: (n) => {
+      if (!isAuthority) return;
+      state = reduceThreshold(state, n);
+      pushAuthoritative();
+    },
+    begin: () => {
+      if (!isAuthority) return;
+      started = true;
+      pushAuthoritative();
+    },
+    reset: () => {
+      if (!isAuthority) return;
+      state = reduceReset(state);
+      started = false;
+      pushAuthoritative();
+    },
+
+    leave: () => session.leave(),
+  };
+}

--- a/votive-patina/main.js
+++ b/votive-patina/main.js
@@ -93,6 +93,16 @@ const els = {}; // cached DOM references
 boot().catch((err) => console.error("votivepatina failed to start:", err));
 
 async function boot() {
+  // Performer stage mode: a live-performance projection of this page, driven by
+  // the realtime channel. Loaded ONLY on demand, so normal visitors never pull in
+  // the stage/realtime layer and the offline page stays offline.
+  const params = new URLSearchParams(location.search);
+  if (params.get("stage") === "performer") {
+    const { setupPerformer } = await import("./lib/performer.js");
+    await setupPerformer({ sessionId: params.get("s") || "live" });
+    return;
+  }
+
   cacheEls();
   document.body.dataset.reducedMotion = reducedMotion ? "1" : "0";
   document.body.dataset.coarsePointer = coarsePointer ? "1" : "0";

--- a/votive-patina/package.json
+++ b/votive-patina/package.json
@@ -6,9 +6,9 @@
   "type": "module",
   "scripts": {
     "serve": "node scripts/serve.mjs",
-    "test:unit": "node --test tests/unit/*.test.mjs",
+    "test:unit": "node --test --test-concurrency=1 tests/unit/*.test.mjs",
     "test:e2e": "playwright test",
-    "lint:html": "html-validate index.html",
+    "lint:html": "html-validate index.html admin/index.html audience/index.html",
     "verify:purity": "node scripts/verify-purity.mjs",
     "test": "npm run test:unit && npm run lint:html && npm run verify:purity && npm run test:e2e"
   },

--- a/votive-patina/scripts/verify-purity.mjs
+++ b/votive-patina/scripts/verify-purity.mjs
@@ -95,10 +95,34 @@ const NETWORK_PATTERNS = [
   "EventSource(",
 ];
 
-// fetch()/import() pointing at an absolute remote URL (http:, https:, or the
-// protocol-relative //host form). Same-origin relative paths (./ , ../ , /data)
-// do not match.
-const REMOTE_CALL_RE = /\b(?:fetch|import)\s*\(\s*[`'"]\s*(?:https?:)?\/\//;
+// The live-performance layer (votivepatina-stage) is allowed exactly ONE remote
+// dependency: the Supabase Realtime client, loaded as an ESM module from esm.sh
+// and talking to the project's *.supabase.co endpoint. Every OTHER remote host
+// stays forbidden, so analytics/tracker CDNs are still caught. (The art's offline
+// principle is relaxed for Supabase only, by design - see the stage PRD.)
+const ALLOWED_REMOTE_HOSTS = [
+  "esm.sh", // ESM CDN serving @supabase/supabase-js
+  /(?:^|\.)supabase\.co$/, // the realtime endpoint (any subdomain)
+];
+
+// A remote reference in shipped JS: fetch("url") / import("url") / import ... from
+// "url", for an absolute (http:, https:) or protocol-relative (//host) URL.
+// Same-origin relative paths (./ , ../ , /data) never match.
+const REMOTE_REF_RE =
+  /(?:\b(?:fetch|import)\s*\(\s*|\bfrom\s+)[`'"]\s*((?:https?:)?\/\/[^`'"\s]+)/gi;
+
+function hostOf(url) {
+  return String(url)
+    .replace(/^(?:https?:)?\/\//, "")
+    .split(/[/?#]/)[0]
+    .toLowerCase();
+}
+
+function hostAllowed(host) {
+  return ALLOWED_REMOTE_HOSTS.some((a) =>
+    a instanceof RegExp ? a.test(host) : a === host,
+  );
+}
 
 function getShippedJsFiles() {
   const files = [];
@@ -114,6 +138,15 @@ function getShippedJsFiles() {
       if (!f.endsWith(".js")) continue;
       if (f === "generative-expansion.js") continue;
       files.push(path.join(libDir, f));
+    }
+  }
+
+  // the live-performance surfaces (votivepatina-stage) ship their own page JS
+  for (const sub of ["admin", "audience", "performer"]) {
+    const dir = path.join(ROOT, sub);
+    if (!fs.existsSync(dir)) continue;
+    for (const f of fs.readdirSync(dir)) {
+      if (f.endsWith(".js")) files.push(path.join(dir, f));
     }
   }
 
@@ -140,8 +173,14 @@ function checkNoNetworkCalls() {
         hits.push(pattern);
       }
     }
-    if (REMOTE_CALL_RE.test(source)) {
-      hits.push("remote fetch()/import() to an absolute URL");
+    // Remote refs are allowed only to the Supabase allowlist; flag anything else.
+    REMOTE_REF_RE.lastIndex = 0;
+    let mm;
+    while ((mm = REMOTE_REF_RE.exec(source)) !== null) {
+      const host = hostOf(mm[1]);
+      if (!hostAllowed(host)) {
+        hits.push(`remote reference to ${host}`);
+      }
     }
 
     if (hits.length > 0) {

--- a/votive-patina/stage.css
+++ b/votive-patina/stage.css
@@ -1,0 +1,474 @@
+/* ─────────────────────────────────────────────────────────────────────────────
+   stage.css - votivepatina-stage
+
+   Shared styles for the live-performance surfaces (performer / audience / admin).
+   Loaded ALONGSIDE styles.css, so it inherits the oulipo tokens (--ink, --bg,
+   --font-*, etc.) and the shared component styles (the decay canvas, .det-box).
+   Vanilla CSS, oulipo brand: white page, black-opacity ink, mono captions,
+   serif/naskh for the prayer text. No shadows, no rounded blobs, no gradients.
+   ──────────────────────────────────────────────────────────────────────────── */
+
+/* the `hidden` attribute must win over the flex/grid display rules below
+   (author `display:flex` would otherwise override the UA `[hidden]` rule). */
+[hidden] {
+  display: none !important;
+}
+
+.stage {
+  min-height: 100vh;
+  margin: 0 auto;
+  max-width: 720px;
+  padding: 1.25rem 1.25rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* the live count - a quiet mono caption, the brand's metadata register */
+.stage-readout {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+.stage-readout b {
+  color: var(--ink-strong);
+  font-weight: 600;
+}
+
+/* the prayer line: translit (mono), arabic (naskh, RTL), english (serif italic) */
+.station-line {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.station-translit {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-subtle);
+}
+.station-arabic {
+  font-family: var(--font-arabic);
+  direction: rtl;
+  font-size: 1.9rem;
+  line-height: 1.4;
+  color: var(--warm-ink);
+}
+.station-english {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 1.15rem;
+  color: var(--ink);
+}
+
+/* the long narration (performer screen) */
+.station-narration {
+  font-family: var(--font-serif);
+  font-size: 1.1rem;
+  line-height: 1.6;
+  color: var(--ink);
+  max-width: 36rem;
+  margin: 0 auto;
+}
+
+/* the movement prompt (audience phone) */
+.station-prompt {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  line-height: 1.55;
+  color: var(--ink);
+}
+
+/* the single audience action - "pass the peace" - on-brand, squared button */
+.peace-btn {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--ink);
+  padding: 0.85rem 1.6rem;
+  cursor: pointer;
+  transition:
+    opacity var(--t-micro) var(--ease-out),
+    border-color var(--t-micro) var(--ease-out);
+}
+.peace-btn:hover {
+  opacity: 0.7;
+}
+.peace-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.peace-btn .pb-en {
+  font-family: var(--font-sans);
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+.peace-btn .pb-ar {
+  font-family: var(--font-arabic);
+  direction: rtl;
+  font-size: 1.05rem;
+  color: var(--warm-ink);
+}
+
+/* a brief confirmation flash after a peace registers */
+.peace-flash {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  min-height: 1.1rem;
+}
+
+/* the tap-to-join entry gate */
+.join-gate {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  text-align: center;
+  padding: 2rem;
+}
+.join-gate h1 {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(1.4rem, 4vw, 1.9rem);
+  color: var(--ink-muted);
+  margin: 0;
+}
+.join-note {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.05em;
+  color: var(--ink-subtle);
+  max-width: 22rem;
+}
+
+/* the audience/performer image */
+.stage-image-wrap {
+  position: relative;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 360px;
+}
+.stage-canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  border: 1px solid var(--rule);
+}
+
+/* the dismissible on-image overlay (audience: station line + prompt over the image).
+   The same visual treatment is reused on the main page in US-010. */
+.img-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: var(--z-panel);
+  /* translucent so the decaying image reads THROUGH the text - an on-image
+     overlay, not an opaque card. A thin scrim keeps the serif legible. */
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(1px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.9rem;
+  padding: 1.6rem 1.2rem 1.2rem;
+  overflow-y: auto;
+}
+.img-overlay[hidden] {
+  display: none;
+}
+.img-overlay-close {
+  position: absolute;
+  top: 0.3rem;
+  right: 0.4rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: var(--ink-muted);
+  cursor: pointer;
+  padding: 0.3rem 0.55rem;
+  min-height: 44px;
+  min-width: 44px;
+}
+.img-overlay-close:hover {
+  color: var(--ink-strong);
+}
+
+/* admin console: a plain operator panel */
+.admin-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+.admin-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--ink-subtle);
+  padding-bottom: 0.8rem;
+}
+.admin-row label {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+.admin-row input[type="number"] {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  width: 5.5rem;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--ink);
+}
+.admin-btn {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.55rem 1.1rem;
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--ink);
+  cursor: pointer;
+  min-height: 44px;
+  transition: opacity var(--t-micro) var(--ease-out);
+}
+.admin-btn:hover {
+  opacity: 0.7;
+}
+.admin-btn[data-variant="danger"] {
+  border-color: var(--yolo-red);
+  color: var(--yolo-red);
+}
+.admin-state {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1.7;
+  color: var(--ink);
+  white-space: pre-wrap;
+}
+
+/* ── performer stage mode (the projected screen) ──────────────────────────── */
+/* when in stage mode, the normal pray UI is hidden and the performer view shown.
+   The "?" (about) stays - it is restyled to sit just right of the QR button. */
+body[data-stage="performer"] .page,
+body[data-stage="performer"] .console-handle,
+body[data-stage="performer"] .console-drawer {
+  display: none !important;
+}
+
+/* the "?" about button, restyled in stage mode to match the QR button's
+   treatment (squared, mono) and made a touch more present on the projection. */
+body[data-stage="performer"] .about-toggle {
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-style: normal;
+  opacity: 0.8;
+}
+
+/* ── access controls, top-right: [ SHOW QR ] [ ? ] (reference screenshot) ──── */
+.stage-qr-btn {
+  position: fixed;
+  top: 1rem;
+  right: 3.7rem; /* sits just left of the 40px "?" at right:1rem */
+  z-index: 61;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: 40px;
+  padding: 0 0.8rem;
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    opacity var(--t-micro) var(--ease-out),
+    border-color var(--t-micro) var(--ease-out);
+}
+.stage-qr-btn:hover,
+.stage-qr-btn:focus-visible {
+  color: var(--ink-strong);
+  border-color: var(--ink-strong);
+}
+.stage-qr-btn .qr-glyph {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+/* the QR overlay: a big scannable code + the join URL, dismissible */
+.qr-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-about);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.2rem;
+  padding: 2rem;
+  background: rgba(255, 255, 255, 0.97);
+}
+.qr-overlay[hidden] {
+  display: none;
+}
+.qr-overlay .qr-code {
+  width: min(70vmin, 460px);
+  height: auto;
+}
+.qr-overlay .qr-code svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+.qr-overlay .qr-url {
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  letter-spacing: 0.04em;
+  color: var(--ink-muted);
+  word-break: break-all;
+  text-align: center;
+  max-width: 30rem;
+}
+.qr-overlay .qr-caption {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 1.1rem;
+  color: var(--ink);
+}
+.performer-stage {
+  min-height: 100vh;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.6rem;
+}
+.perf-head {
+  text-align: center;
+}
+.perf-title {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  color: var(--ink-muted);
+  margin: 0 0 0.4rem;
+}
+.perf-body {
+  display: flex;
+  gap: 2.5rem;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+.perf-image-wrap {
+  flex: 0 0 auto;
+  width: min(38vw, 320px);
+}
+.perf-canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  border: 1px solid var(--rule);
+}
+.perf-text {
+  flex: 1 1 0;
+  max-width: 34rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.perf-text .station-line {
+  text-align: left;
+  align-items: flex-start;
+}
+
+/* the threads of light: one per station, lit as each station completes */
+.perf-threads {
+  display: flex;
+  gap: 0.7rem;
+  width: 100%;
+  max-width: 640px;
+}
+.perf-thread {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  align-items: center;
+}
+.perf-thread-line {
+  width: 100%;
+  border-top: 2px dashed var(--ink-subtle);
+  transition:
+    border-color 700ms var(--ease-out),
+    border-top-style 0ms;
+}
+.perf-thread[data-lit="true"] .perf-thread-line {
+  border-top-style: solid;
+  border-top-color: var(--glow);
+  filter: drop-shadow(0 0 4px var(--glow));
+}
+.perf-thread-num {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  color: var(--ink-subtle);
+}
+.perf-thread[data-lit="true"] .perf-thread-num {
+  color: var(--ink-muted);
+}
+
+@media (max-width: 720px) {
+  .perf-body {
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+  .perf-image-wrap {
+    width: min(70vw, 260px);
+  }
+  .perf-text .station-line {
+    text-align: center;
+    align-items: center;
+  }
+}
+
+/* offline/loopback + finale banners */
+.stage-banner {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-subtle);
+  text-align: center;
+}
+.is-finale .station-arabic {
+  color: var(--ink-strong);
+}

--- a/votive-patina/tasks/prd-votivepatina-stage.md
+++ b/votive-patina/tasks/prd-votivepatina-stage.md
@@ -1,0 +1,343 @@
+# PRD: votivepatina-stage (live performance layer)
+
+## Overview
+
+Add a staged, multi-device performance layer on top of the existing votivepatina
+piece (`votive-patina/`, oulipo.xyz/votive-patina/). Three surfaces - a performer
+display, many audience phones that join by QR, and an admin console - stay in sync
+live via Supabase Realtime. The audience (arranged on a Zoom grid) drives the piece
+by "passing the peace": a deliberate phone gesture that registers as one peace. Each
+crossing of a per-station threshold advances the station, reveals the next
+translation as a dismissible on-image overlay, lights the next thread of light, and
+steps the generational JPEG decay one generation. There are 5 stations - the five
+prayer lines, each with long-form narration and a directional prompt - so the image
+is fully decayed by the finale ("Amin"). Reuse the existing image, decay engine,
+detection boxes, console prayer, and translation overlay; extend, do not rebuild.
+
+## Goals
+
+- Three surfaces (performer / `/audience` / `/admin`) that stay in sync live over
+  Supabase Realtime, with no bundler, deployed on Vercel over HTTPS.
+- Audience phone: tap-to-join -> iOS motion permission -> one peace per station, with
+  a visible manual fallback when motion is denied or unavailable.
+- Crossing the per-station threshold (`PASSES_PER_STATION`, default = audience size N,
+  tunable live in admin) advances the station on every surface, shows the dismissible
+  on-image translation, lights the next thread, and steps the decay one generation.
+- Decay reuses the existing generational-JPEG engine: one generation per station, fully
+  decayed at the last station (5 stations -> `decayGen` 0..5, matching `MAX_STEP` 5).
+- A live "{peaceCount} people passed the peace" readout on performer and audience.
+- The translation appears as a dismissible overlay ON TOP of the image on the main page
+  (mobile + desktop) and the same overlay is reused on `/audience`.
+- Access controls top-right: a QR button styled per the reference screenshot and the
+  existing "?" restyled to match and moved to its right; the "pray for us" button and
+  all drifted fonts brought back in line with the design system.
+- All quality gates green, including new multi-surface e2e and a 2-client realtime-sync
+  test; the piece verified on mobile and desktop.
+
+## Quality Gates
+
+These commands must pass for every user story (run from `votive-patina/`):
+
+- `npm run test:unit` - Node `--test` unit suite (decay curve, prayer strings, plus the
+  new stations-data and performance-state reducer tests).
+- `npm run lint:html` - `html-validate` on every shipped HTML entry (index.html and the
+  new audience/admin pages).
+- `npm run verify:purity` - UPDATED for this build: the no-network check now allowlists
+  the Supabase Realtime client (the `@supabase/supabase-js` ESM module from the CDN and
+  the project's `*.supabase.co` realtime endpoint). It still BLOCKS analytics/trackers
+  and any other remote host, still forbids minification, and still asserts the ASCII
+  relic + intact comments. No bundler is introduced.
+- `npm run test:e2e` - Playwright across mobile / desktop / reduced-motion, including the
+  new performer/audience/admin specs, synthetic-devicemotion tests, and a 2-client
+  realtime-sync test (loopback / mocked transport so it runs offline in CI).
+- Visual verification (REQUIRED for UI stories): preview server + screenshots on mobile
+  and desktop of the restyled top-right controls, the on-image overlay, and the threads
+  lighting across stations.
+
+## User Stories
+
+### US-001: Relax the purity gate + scaffold the realtime layer
+
+**Description:** As the builder, I want the purity check updated and a shared realtime
+module in place so the stage layer can use Supabase without a bundler and without
+weakening the no-tracker stance.
+
+**Acceptance Criteria:**
+
+- [ ] `scripts/verify-purity.mjs` allowlists the Supabase Realtime client (the
+      `@supabase/supabase-js` ESM import URL and the `*.supabase.co` realtime endpoint),
+      still flags any OTHER remote host or analytics/tracker call, still forbids
+      minification, and still asserts the relic + comments. `npm run verify:purity` passes.
+- [ ] `lib/realtime.js` exports a `joinSession({ sessionId, role })` that loads the
+      Supabase client from the CDN ESM, opens a channel named for the session id, and
+      exposes `broadcast(state)`, `onState(cb)`, `sendPeace(payload)`, `onPeace(cb)`,
+      and presence join/leave with a connected-count callback. No bundler is added.
+- [ ] Supabase config (oulipo_main URL + publishable anon key) lives in one
+      `lib/realtime-config.js`; the key is the publishable anon key only (no service key).
+- [ ] A smoke test connects two channel clients over a loopback/mocked transport and
+      confirms a broadcast from one reaches the other.
+
+### US-002: Stations data model (the 5-station score)
+
+**Description:** As the builder, I want the performance score encoded as data so every
+surface renders the same stations in order.
+
+**Acceptance Criteria:**
+
+- [ ] `data/stations.json` defines exactly 5 stations in order, each with:
+      `{ index, translit, arabic, english, narration, prompt, direction }` where
+      `direction` is one of `right | left | up | down | heart`.
+- [ ] The five `arabic` values equal the existing `ARABIC_LINES`
+      (بحضنك خذينا / وعن كل شر ابعدينا / يا أم يسوع / تشفعي فينا / أمين), in order; the
+      `narration` and `prompt` fields carry Halim's provided text per station.
+- [ ] An optional `preroll` block holds the opening narration + the "scan this QR" cue.
+- [ ] A unit test asserts: exactly 5 stations, correct order, all required fields present
+      and non-empty, and `direction` within the allowed set.
+
+### US-003: Shared performance-state reducer
+
+**Description:** As the builder, I want a pure state module so threshold logic and
+dedupe are deterministic and unit-testable, independent of the transport.
+
+**Acceptance Criteria:**
+
+- [ ] A pure module exposes the state `{ peaceCount, stationIndex, decayGen, threadsLit,
+passesThisStation }` and `applyPeace(state, { deviceId, stationIndex })`,
+      `setThreshold(n)`, and `reset()`.
+- [ ] `applyPeace` increments `peaceCount` and `passesThisStation`, but is a no-op when
+      the same `deviceId` already passed at the current `stationIndex` (dedupe per device
+      per station) or when `stationIndex` is past the finale.
+- [ ] When `passesThisStation` reaches `PASSES_PER_STATION`, the station advances by
+      exactly one: `stationIndex += 1`, `decayGen = stationIndex`, `threadsLit = stationIndex`,
+      `passesThisStation = 0`. Reaching the last station sets the finale flag.
+- [ ] `reset()` returns `peaceCount=0, stationIndex=0, decayGen=0, threadsLit=0`.
+- [ ] Unit tests cover: increment, dedupe per device per station, exactly-one-advance at
+      threshold, decay/threads bump with the advance, finale at station 5, and reset.
+
+### US-004: Realtime sync (broadcast + presence, single authority)
+
+**Description:** As any surface, I want one authoritative state so peaces from many
+phones never double-count and every screen shows the same numbers live.
+
+**Acceptance Criteria:**
+
+- [ ] One host (the performer, or admin if no performer) owns the reducer: audience
+      surfaces `sendPeace({ deviceId, stationIndex })`; the host applies it and
+      `broadcast`s the new state; all surfaces render from the broadcast.
+- [ ] Presence reports the count of connected audience devices to the admin.
+- [ ] A 2-client e2e test (two browser contexts, loopback/mocked transport): a peace from
+      client A is reflected in client B's `peaceCount` within 2s; presence shows 2; a
+      duplicate peace from A at the same station does not change the count.
+
+### US-005: Performer page (existing main page in stage mode)
+
+**Description:** As the performer, I want the existing main page to run in stage mode,
+showing the synced decay and the current station, so the room sees one shared image.
+
+**Acceptance Criteria:**
+
+- [ ] A stage-mode entry (e.g. `?stage=performer` or `/performer`) on the existing page
+      subscribes to the channel and renders: the Mary image at the synced `decayGen`, the
+      current station's line + narration, the live "{peaceCount} people passed the peace"
+      readout, and the threads of light with `threadsLit` of 5 lit.
+- [ ] The performer surface does NOT request device motion and does not emit peaces.
+- [ ] e2e: injecting a channel state (`stationIndex`, `decayGen`, `peaceCount`,
+      `threadsLit`) renders the matching station text, the canvas at the right decay
+      generation, the right number of lit threads, and the readout value.
+
+### US-006: Audience page `/audience` (join + sync)
+
+**Description:** As an audience member, I want to scan the QR, tap to join, and see the
+same image and count as the room.
+
+**Acceptance Criteria:**
+
+- [ ] `/audience` shows a "Tap to join" entry that, on tap, calls
+      `DeviceMotionEvent.requestPermission()` where present (iOS 13+) and joins the channel.
+- [ ] After joining it shows the synced Mary image at the same `decayGen`, the
+      "{peaceCount} people passed the peace" readout, and the current station's line +
+      movement prompt as a dismissible on-image overlay.
+- [ ] e2e: tap-to-join transitions to a joined state; an injected channel state syncs the
+      image decay and the readout; the overlay shows the current line + prompt and is
+      dismissible (tap-outside and X).
+
+### US-007: Passing the peace (motion + dedupe + manual fallback)
+
+**Description:** As an audience member, I want a deliberate phone motion to register as
+exactly one peace for this station, with a button if motion is blocked.
+
+**Acceptance Criteria:**
+
+- [ ] Detection is magnitude-based: acceleration magnitude over a threshold, debounced so
+      one deliberate motion emits one peace; direction is choreographic (not verified).
+- [ ] A peace is deduped per device per station: repeated shaking within the same station
+      emits at most one peace; after the station advances, one new peace is allowed.
+- [ ] When motion permission is denied or `DeviceMotionEvent` is unavailable, a visible
+      manual "pass the peace" button is shown and emits exactly one (deduped) peace.
+- [ ] e2e with synthetic `devicemotion` events: one strong motion -> one peace; rapid
+      repeats -> still one; post-advance -> one more allowed; denied-permission path shows
+      and exercises the manual button.
+
+### US-008: Admin page `/admin` (N, threshold, reset)
+
+**Description:** As the operator, I want to set the audience size and threshold and reset
+cleanly between performances.
+
+**Acceptance Criteria:**
+
+- [ ] `/admin` lets the operator set audience size N and `PASSES_PER_STATION` (default = N)
+      live, and shows the presence-based connected-device count next to N.
+- [ ] Changing `PASSES_PER_STATION` takes effect for the next threshold evaluation without
+      reload.
+- [ ] A Reset control zeroes `peaceCount`, sets `decayGen=0`, `stationIndex=0`, threads off,
+      and all surfaces reflect generation 0 / station 0 within 2s.
+- [ ] e2e: changing the threshold then driving peaces advances at the new threshold; reset
+      returns every surface to the start state.
+
+### US-009: Threshold -> advance, end to end
+
+**Description:** As the room, when enough of us pass the peace, I want the station to
+advance everywhere at once - overlay, thread, and decay together.
+
+**Acceptance Criteria:**
+
+- [ ] When `passesThisStation` reaches `PASSES_PER_STATION`, the station advances exactly
+      once: the next overlay appears on performer + audience, `threadsLit` increments, and
+      `decayGen` increments (one generation).
+- [ ] Reaching the last station lights all 5 threads and sets the finale state; further
+      peaces do not advance past the finale.
+- [ ] e2e (2 clients driving peaces to threshold): exactly one advance per threshold,
+      overlay + threads + decay update together on both surfaces, and the finale lights all
+      5 threads at station 5.
+
+### US-010: On-image translation overlay on the main page
+
+**Description:** As a visitor (and as audience), I want a text's translation to appear on
+top of the image as an easily dismissible overlay, on mobile and desktop.
+
+**Acceptance Criteria:**
+
+- [ ] On the existing main page, opening a detection-box translation shows it as an overlay
+      ON TOP of the image (not a separate panel below), dismissible by tap-outside and by an
+      X, on both mobile and desktop.
+- [ ] The overlay is a single reusable module imported by both the main page and `/audience`
+      (no duplication).
+- [ ] e2e: main page - clicking a text box opens the on-image overlay; tap-outside and X
+      both dismiss; verified at mobile and desktop viewports.
+
+### US-011: Design-system conformance (QR + "?" controls, "pray for us", fonts)
+
+**Description:** As Halim, I want the access controls and type to match my design system
+and the reference screenshot.
+
+**Acceptance Criteria:**
+
+- [ ] Top-right: a "SHOW QR" button styled per the reference (bordered box, mono uppercase,
+      QR glyph) that opens/zooms a scannable QR encoding the absolute `/audience` URL
+      (with session id); the existing "?" is restyled to the same treatment and sits to the
+      RIGHT of the QR button.
+- [ ] The "pray for us" button is restyled to the design system; fonts that have drifted are
+      brought back to the design-system tokens (Standard / Terminal Grotesque / Diatype per
+      the oulipo brand).
+- [ ] Visual verification: mobile + desktop screenshots show the two controls top-right in
+      the reference style; an e2e check asserts the QR target resolves to `/audience` and the
+      "pray for us" button + headings use the expected font-family/classes.
+
+### US-012: Full dry-run, test suite, and docs
+
+**Description:** As the builder, I want a scripted end-to-end dry run and updated docs so a
+performance can be run and re-run with confidence.
+
+**Acceptance Criteria:**
+
+- [ ] An e2e "dry run": admin sets N + threshold, two audience clients join, peaces are
+      driven through all 5 stations to the finale with the performer reflecting each advance,
+      then reset returns to the start - all assertions pass.
+- [ ] All four gates pass (`test:unit`, `lint:html`, `verify:purity`, `test:e2e`).
+- [ ] `README.md` / `Context.md` document the three surfaces, the Supabase channel contract
+      (the broadcast fields and the peace payload), the routing, and an on-device iOS motion
+      checklist for show day.
+
+## Functional Requirements
+
+- FR-1: The system must run three surfaces - performer (the existing page in stage mode),
+  `/audience`, and `/admin` - that share live state over a single Supabase Realtime channel
+  keyed to a session id, with no bundler and over HTTPS on Vercel.
+- FR-2: Shared state is `{ peaceCount, stationIndex, decayGen, threadsLit }`; a single host
+  is authoritative and broadcasts state; audience surfaces emit peace events only.
+- FR-3: A peace is one deliberate phone motion (magnitude threshold + debounce), deduped per
+  device per station; a manual button is the fallback when motion is unavailable or denied.
+- FR-4: When a station's peaces reach `PASSES_PER_STATION` (default = N, set live in admin),
+  the station advances by one and `decayGen` and `threadsLit` each increment by one; the last
+  station is the finale with all threads lit.
+- FR-5: `decayGen` drives the existing generational-JPEG decay engine (`renderStep`), one
+  generation per station, 0..5 across the 5 stations.
+- FR-6: The performer shows the station line + narration + the live peace readout; the audience
+  shows the synced image + the line + the movement prompt as a dismissible on-image overlay +
+  the same readout.
+- FR-7: The translation overlay on the main page renders on top of the image and is dismissible
+  (tap-outside / X) on mobile and desktop; the same module is reused on `/audience`.
+- FR-8: Admin can set N and `PASSES_PER_STATION` live and reset all state (peaces 0, decay gen 0,
+  station 0, threads off) between performances; presence reports connected device count.
+- FR-9: Access controls sit top-right: a QR button (per the reference screenshot) opening a QR to
+  `/audience`, and the restyled "?" to its right; the "pray for us" button and fonts conform to
+  the oulipo design system.
+- FR-10: `verify:purity` is updated to allow the Supabase Realtime client and `*.supabase.co`
+  endpoint only, while still blocking analytics/trackers and minification and asserting the relic.
+
+## Non-Goals (Out of Scope)
+
+- No bundler, framework, or build step; vanilla JS + ESM from CDN only.
+- No Zoom integration - the Zoom grid is the human layer; this build only drives phones + screens.
+- No directional gesture detection - magnitude only; the prompt's direction is choreographic.
+- No persistence of ephemeral performance state beyond the channel (only session config N /
+  threshold may persist if needed); no database schema work required for the core flow.
+- No heavyweight admin auth - an obscured route (and optional shared passcode) is enough; not a
+  user-accounts system.
+- Not redesigning the decay engine, the detection boxes, or the console-prayer plumbing - reuse them.
+- Not translating or rewriting the provided narration; it is used verbatim per station.
+
+## Technical Considerations
+
+- Realtime: `@supabase/supabase-js` loaded as ESM from a CDN (esm.sh / skypack); Realtime
+  broadcast + presence on a per-session channel. Project: oulipo_main (ref smytgqkgomsfyurskpcl);
+  publishable anon key only. Single-authority reducer avoids double-counting across phones.
+- Routing on Vercel (static): `/votive-patina/audience/` and `/votive-patina/admin/` as their own
+  `index.html`; performer is the main page in stage mode (`?stage=performer` or a `/performer/`
+  rewrite). Confirm the path scheme during US-005/006/008.
+- Motion: `DeviceMotionEvent.requestPermission()` must be called from the tap-to-join user
+  gesture (iOS 13+); HTTPS required (Vercel is fine). Magnitude from `accelerationIncludingGravity`
+  with a gravity-baseline subtraction, threshold + debounce, dedupe via a local set keyed by
+  `stationIndex`.
+- Decay: reuse `createDecayEngine` + `renderStep(stationIndex)`; the top-card `MAX_STEP` is 5, so
+  5 stations map cleanly to generations 0..5 (pristine at preroll, fully worn at "Amin").
+- Threads of light: reuse / adapt the existing constellation rays as 5 threads (or a dedicated
+  5-thread SVG echoing the reference line drawing); light `threadsLit` of them. Keep the mobile
+  bounds fix in mind (no horizontal overflow).
+- QR: generate client-side (a small QR lib via ESM, or a prebuilt SVG) encoding the absolute
+  `/audience` URL with the session id.
+- Testing: drive `devicemotion` and channel state via injected events in Playwright; the 2-client
+  sync test uses a loopback/mocked transport so CI runs offline; keep the existing
+  mobile/desktop/reduced-motion projects.
+
+## Success Metrics
+
+- All four gates green; the dry-run e2e walks all 5 stations to the finale and resets.
+- On show day: phones join by QR, tap-to-join grants motion (or fall back to the button), a peace
+  registers once per station, the live count matches the room, each threshold advances the station
+  with overlay + thread + decay together, and the image is fully worn by "Amin".
+- The main-page translation reads as an on-image overlay on mobile and desktop; the top-right QR +
+  "?" and the "pray for us" button match the design system and the reference screenshot.
+
+## Open Questions
+
+- Admin access: open obscured URL, or a shared passcode / `?key=` guard? (Assumed: obscured route,
+  optional passcode.)
+- Session id: admin-generated and held for the show (QR encodes it) vs a fixed id. (Assumed:
+  admin generates/holds it.)
+- Threads visual: adapt the 11-satellite constellation rays down to 5 threads, or a dedicated
+  5-thread line per the screenshot? (Assumed: 5 threads, design tuned against the reference.)
+- Preroll: show the opening narration + "scan this QR" as a station-0 screen on the performer?
+  (Assumed: yes, a preroll state before station 1.)
+- Does the audience phone show the decaying image, or only the line + prompt + count? (Assumed:
+  it shows the synced image too, per the brief.)

--- a/votive-patina/tests/e2e/stage-access.spec.mjs
+++ b/votive-patina/tests/e2e/stage-access.spec.mjs
@@ -1,0 +1,61 @@
+/**
+ * tests/e2e/stage-access.spec.mjs
+ *
+ * US-011: the top-right access controls on the performer stage.
+ *   - SHOW QR + "?" are present in performer mode, absent on the normal page
+ *   - SHOW QR opens an overlay carrying the audience join URL
+ *   - the "?" opens the About modal
+ *
+ * Offline (loopback). The QR svg itself is generated from a CDN at show time and
+ * is not asserted here; the join URL is the offline-verifiable fallback.
+ */
+
+import { test, expect } from "@playwright/test";
+
+const PERF = "/?stage=performer&s=acc123&rt=loopback";
+
+test.describe("stage access controls (QR + about)", () => {
+  test("the normal page does NOT show the QR button", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("#stage-qr-btn")).toBeHidden();
+    // the normal "?" is still there
+    await expect(page.locator("#about-toggle")).toBeVisible();
+  });
+
+  test("performer mode shows SHOW QR and the '?' top-right", async ({
+    page,
+  }) => {
+    await page.goto(PERF);
+    await page.waitForFunction(() => !!window.__stage);
+    await expect(page.locator("#stage-qr-btn")).toBeVisible();
+    await expect(page.locator("#about-toggle")).toBeVisible();
+    // the "?" sits to the right of the QR button
+    const qr = await page.locator("#stage-qr-btn").boundingBox();
+    const help = await page.locator("#about-toggle").boundingBox();
+    expect(help.x).toBeGreaterThan(qr.x);
+  });
+
+  test("SHOW QR opens an overlay carrying the audience join URL", async ({
+    page,
+  }) => {
+    await page.goto(PERF);
+    await page.waitForFunction(() => !!window.__stage);
+    await expect(page.locator("#qr-overlay")).toBeHidden();
+    await page.locator("#stage-qr-btn").click();
+    await expect(page.locator("#qr-overlay")).toBeVisible();
+    const url = await page.locator("#qr-url").innerText();
+    expect(url).toContain("/audience/");
+    expect(url).toContain("s=acc123");
+    // dismiss
+    await page.locator("#qr-close").click();
+    await expect(page.locator("#qr-overlay")).toBeHidden();
+  });
+
+  test("the '?' opens the About modal in performer mode", async ({ page }) => {
+    await page.goto(PERF);
+    await page.waitForFunction(() => !!window.__stage);
+    await expect(page.locator("#about-modal")).toBeHidden();
+    await page.locator("#about-toggle").click();
+    await expect(page.locator("#about-modal")).toBeVisible();
+  });
+});

--- a/votive-patina/tests/e2e/stage-motion.spec.mjs
+++ b/votive-patina/tests/e2e/stage-motion.spec.mjs
@@ -1,0 +1,126 @@
+/**
+ * tests/e2e/stage-motion.spec.mjs
+ *
+ * US-007: "passing the peace" by phone motion, plus the manual fallback.
+ *   - a deliberate motion (synthetic devicemotion) registers exactly one peace
+ *   - rapid repeats within the station do not double-count
+ *   - when motion permission is denied, the manual button still passes the peace
+ *
+ * Uses the offline loopback transport (admin authority + audience in one context).
+ */
+
+import { test, expect } from "@playwright/test";
+
+function ids() {
+  const sid = "motion-" + Math.floor(Math.random() * 1e6);
+  return {
+    ADMIN: `/admin/?s=${sid}&rt=loopback`,
+    AUD: `/audience/?s=${sid}&rt=loopback`,
+  };
+}
+
+async function bringUp(
+  context,
+  { ADMIN, AUD },
+  { threshold = 5, denyMotion = false } = {},
+) {
+  const admin = await context.newPage();
+  const audience = await context.newPage();
+  if (denyMotion) {
+    await audience.addInitScript(() => {
+      // Simulate iOS denying motion permission.
+      if (typeof DeviceMotionEvent !== "undefined") {
+        DeviceMotionEvent.requestPermission = async () => "denied";
+      }
+    });
+  }
+  await admin.goto(ADMIN);
+  await admin.waitForFunction(() => !!window.__stage);
+  await audience.goto(AUD);
+  await audience.locator("#join-btn").click();
+  await audience.waitForFunction(() => !!window.__stage);
+  await admin.locator("#threshold-input").fill(String(threshold));
+  await admin.locator("#threshold-input").dispatchEvent("change");
+  await admin.locator("#begin-btn").click();
+  await expect(audience.locator("body")).toHaveAttribute(
+    "data-phase",
+    "active",
+    {
+      timeout: 4000,
+    },
+  );
+  return { admin, audience };
+}
+
+// Dispatch a synthetic devicemotion with a given magnitude on each axis.
+async function fireMotion(page, mag) {
+  await page.evaluate((m) => {
+    let ev;
+    try {
+      ev = new DeviceMotionEvent("devicemotion", {
+        accelerationIncludingGravity: { x: m, y: m, z: m },
+      });
+    } catch {
+      ev = new Event("devicemotion");
+      Object.defineProperty(ev, "accelerationIncludingGravity", {
+        value: { x: m, y: m, z: m },
+      });
+    }
+    window.dispatchEvent(ev);
+  }, mag);
+}
+
+test.describe("passing the peace - motion + fallback", () => {
+  test("a deliberate motion registers exactly one peace", async ({
+    context,
+  }) => {
+    const { admin, audience } = await bringUp(context, ids());
+    // First event primes the baseline; the spike then clears the threshold.
+    await fireMotion(audience, 2); // baseline (near rest)
+    await audience.waitForTimeout(60);
+    await fireMotion(audience, 45); // a deliberate move
+    await expect
+      .poll(
+        async () =>
+          (await admin.evaluate(() => window.__stage.getState())).peaceCount,
+        {
+          timeout: 4000,
+        },
+      )
+      .toBe(1);
+  });
+
+  test("rapid repeats within the same station do not double-count", async ({
+    context,
+  }) => {
+    const { admin, audience } = await bringUp(context, ids());
+    await fireMotion(audience, 2);
+    await audience.waitForTimeout(60);
+    await fireMotion(audience, 45);
+    await fireMotion(audience, 48);
+    await fireMotion(audience, 50);
+    await audience.waitForTimeout(400);
+    expect(
+      (await admin.evaluate(() => window.__stage.getState())).peaceCount,
+    ).toBe(1);
+  });
+
+  test("denied motion permission: the manual button still passes the peace", async ({
+    context,
+  }) => {
+    const { admin, audience } = await bringUp(context, ids(), {
+      denyMotion: true,
+    });
+    await expect(audience.locator("#peace-btn")).toBeEnabled();
+    await audience.locator("#peace-btn").click();
+    await expect
+      .poll(
+        async () =>
+          (await admin.evaluate(() => window.__stage.getState())).peaceCount,
+        {
+          timeout: 4000,
+        },
+      )
+      .toBe(1);
+  });
+});

--- a/votive-patina/tests/e2e/stage-performer.spec.mjs
+++ b/votive-patina/tests/e2e/stage-performer.spec.mjs
@@ -1,0 +1,150 @@
+/**
+ * tests/e2e/stage-performer.spec.mjs
+ *
+ * US-005 (performer stage mode) + US-009 (threshold -> advance everywhere) +
+ * US-012 (a full dry-run). Admin authority + performer + audience over the offline
+ * loopback transport. The performer is a pure renderer of the synced state.
+ */
+
+import { test, expect } from "@playwright/test";
+
+function ids() {
+  const sid = "perf-" + Math.floor(Math.random() * 1e6);
+  return {
+    ADMIN: `/admin/?s=${sid}&rt=loopback`,
+    PERF: `/?stage=performer&s=${sid}&rt=loopback`,
+    AUD: `/audience/?s=${sid}&rt=loopback`,
+  };
+}
+
+async function state(page) {
+  return page.evaluate(() => window.__stage && window.__stage.getState());
+}
+
+// Click the audience peace button, then wait for the authority to advance.
+async function passAndAdvance(audience, admin, fromStation) {
+  await expect(audience.locator("#peace-btn")).toBeEnabled({ timeout: 4000 });
+  await audience.locator("#peace-btn").click();
+  await expect
+    .poll(async () => (await state(admin)).stationIndex, { timeout: 4000 })
+    .toBe(fromStation + 1);
+}
+
+test.describe("performer stage mode + full dry-run", () => {
+  test("performer renders the synced station, decay, and threads", async ({
+    context,
+  }) => {
+    const { ADMIN, PERF, AUD } = ids();
+    const admin = await context.newPage();
+    const performer = await context.newPage();
+    const audience = await context.newPage();
+
+    await admin.goto(ADMIN);
+    await admin.waitForFunction(() => !!window.__stage);
+
+    await performer.goto(PERF);
+    await performer.waitForFunction(() => !!window.__stage);
+    // stage mode reveals the performer view and hides the normal page
+    await expect(performer.locator("#performer-stage")).toBeVisible();
+    await expect(performer.locator(".page")).toBeHidden();
+    // five threads of light, none lit yet
+    await expect(performer.locator(".perf-thread")).toHaveCount(5);
+
+    await audience.goto(AUD);
+    await audience.locator("#join-btn").click();
+    await audience.waitForFunction(() => !!window.__stage);
+
+    // 1 peace per station.
+    await admin.locator("#threshold-input").fill("1");
+    await admin.locator("#threshold-input").dispatchEvent("change");
+    await admin.locator("#begin-btn").click();
+
+    // Active: the performer shows station 1's line + narration, no threads lit.
+    await expect(performer.locator("body")).toHaveAttribute(
+      "data-phase",
+      "active",
+      {
+        timeout: 4000,
+      },
+    );
+    await expect(performer.locator("#perf-translit")).toHaveText(
+      "FI KHOUDNIKI KHOUZINA",
+    );
+    await expect(performer.locator("#perf-narration")).toContainText(
+      "Embrace us",
+    );
+    expect(
+      await performer.locator('.perf-thread[data-lit="true"]').count(),
+    ).toBe(0);
+
+    // One peace -> station advances; the performer reflects station 2, 1 thread,
+    // and one generation of decay.
+    await passAndAdvance(audience, admin, 0);
+    await expect(performer.locator("#perf-translit")).toHaveText(
+      "WA 3AN KOULLI CHARREN 2EB3IDINA",
+      { timeout: 4000 },
+    );
+    await expect
+      .poll(async () =>
+        performer.locator('.perf-thread[data-lit="true"]').count(),
+      )
+      .toBe(1);
+    await expect(performer.locator("#perf-count")).toHaveText("1");
+    expect((await state(performer)).decayGen).toBe(1);
+  });
+
+  test("full dry-run: walk all 5 stations to the finale, then reset", async ({
+    context,
+  }) => {
+    const { ADMIN, PERF, AUD } = ids();
+    const admin = await context.newPage();
+    const performer = await context.newPage();
+    const audience = await context.newPage();
+
+    await admin.goto(ADMIN);
+    await admin.waitForFunction(() => !!window.__stage);
+    await performer.goto(PERF);
+    await performer.waitForFunction(() => !!window.__stage);
+    await audience.goto(AUD);
+    await audience.locator("#join-btn").click();
+    await audience.waitForFunction(() => !!window.__stage);
+
+    await admin.locator("#threshold-input").fill("1");
+    await admin.locator("#threshold-input").dispatchEvent("change");
+    await admin.locator("#begin-btn").click();
+    await expect(audience.locator("body")).toHaveAttribute(
+      "data-phase",
+      "active",
+    );
+
+    // Walk all five stations.
+    for (let s = 0; s < 5; s++) {
+      await passAndAdvance(audience, admin, s);
+    }
+
+    // Finale: all threads lit, image fully worn, finale flag everywhere.
+    const fin = await state(performer);
+    expect(fin.finale).toBe(true);
+    expect(fin.decayGen).toBe(5);
+    expect(fin.threadsLit).toBe(5);
+    expect(fin.peaceCount).toBe(5);
+    await expect(performer.locator("body")).toHaveAttribute(
+      "data-phase",
+      "finale",
+    );
+    expect(
+      await performer.locator('.perf-thread[data-lit="true"]').count(),
+    ).toBe(5);
+
+    // Reset returns every surface to the start.
+    await admin.locator("#reset-btn").click();
+    await expect
+      .poll(async () => (await state(performer)).decayGen, { timeout: 4000 })
+      .toBe(0);
+    const reset = await state(performer);
+    expect(reset.stationIndex).toBe(0);
+    expect(reset.peaceCount).toBe(0);
+    expect(reset.threadsLit).toBe(0);
+    expect(reset.finale).toBe(false);
+  });
+});

--- a/votive-patina/tests/e2e/stage-sync.spec.mjs
+++ b/votive-patina/tests/e2e/stage-sync.spec.mjs
@@ -1,0 +1,132 @@
+/**
+ * tests/e2e/stage-sync.spec.mjs
+ *
+ * US-004 (+US-006/007/008): the live control plane synced over the OFFLINE
+ * loopback transport (BroadcastChannel bridges two pages in one context, so the
+ * test runs with no network). Admin is the authority; audience joins, passes the
+ * peace, and the state advances on every surface. Dedupe + presence verified.
+ *
+ * Both pages expose window.__stage; we assert against __stage.getState().
+ */
+
+import { test, expect } from "@playwright/test";
+
+const SID = "sync-" + Math.floor(Math.random() * 1e6);
+const ADMIN = `/admin/?s=${SID}&rt=loopback`;
+const AUD = `/audience/?s=${SID}&rt=loopback`;
+
+async function stageState(page) {
+  return page.evaluate(() => window.__stage && window.__stage.getState());
+}
+
+test.describe("stage live sync (loopback)", () => {
+  test("a peace from the audience advances the station on every surface", async ({
+    context,
+  }) => {
+    const admin = await context.newPage();
+    const audience = await context.newPage();
+
+    // Admin (authority) first so it is present to broadcast.
+    await admin.goto(ADMIN);
+    await admin.waitForFunction(() => !!window.__stage);
+    expect(await admin.evaluate(() => window.__stage.mode)).toBe("loopback");
+
+    // Audience joins (the tap grants motion on iOS; here it just joins).
+    await audience.goto(AUD);
+    await audience.locator("#join-btn").click();
+    await audience.waitForFunction(() => !!window.__stage);
+    await expect(audience.locator("#live")).toBeVisible();
+
+    // Admin: set a 1-peace threshold and begin the show.
+    await admin.locator("#threshold-input").fill("1");
+    await admin.locator("#threshold-input").dispatchEvent("change");
+    await admin.locator("#begin-btn").click();
+
+    // The audience should reach the active phase and enable the peace button.
+    await expect(audience.locator("body")).toHaveAttribute(
+      "data-phase",
+      "active",
+      {
+        timeout: 4000,
+      },
+    );
+    await expect(audience.locator("#peace-btn")).toBeEnabled();
+
+    // Pass the peace.
+    await audience.locator("#peace-btn").click();
+
+    // Authority advances exactly one station, decay steps once.
+    await expect
+      .poll(async () => (await stageState(admin)).stationIndex, {
+        timeout: 4000,
+      })
+      .toBe(1);
+    const adminState = await stageState(admin);
+    expect(adminState.peaceCount).toBe(1);
+    expect(adminState.decayGen).toBe(1);
+    expect(adminState.threadsLit).toBe(1);
+
+    // The audience surface reflects the same peaceCount live.
+    await expect
+      .poll(async () => (await stageState(audience)).peaceCount, {
+        timeout: 4000,
+      })
+      .toBe(1);
+    await expect(audience.locator("#peace-count")).toHaveText("1");
+  });
+
+  test("a duplicate peace from the same device does not double-count", async ({
+    context,
+  }) => {
+    const admin = await context.newPage();
+    const audience = await context.newPage();
+
+    await admin.goto(ADMIN + "-dup");
+    await admin.waitForFunction(() => !!window.__stage);
+    await audience.goto(AUD + "-dup");
+    await audience.locator("#join-btn").click();
+    await audience.waitForFunction(() => !!window.__stage);
+
+    // Threshold 5 so a single peace does NOT advance the station.
+    await admin.locator("#threshold-input").fill("5");
+    await admin.locator("#threshold-input").dispatchEvent("change");
+    await admin.locator("#begin-btn").click();
+    await expect(audience.locator("body")).toHaveAttribute(
+      "data-phase",
+      "active",
+    );
+
+    await audience.locator("#peace-btn").click();
+    await expect
+      .poll(async () => (await stageState(admin)).peaceCount, { timeout: 4000 })
+      .toBe(1);
+
+    // The button disables after passing; force a second send via the stage API.
+    await audience.evaluate(() => window.__stage.passPeace());
+    await audience.waitForTimeout(400);
+    expect((await stageState(admin)).peaceCount).toBe(1);
+    expect((await stageState(admin)).passesThisStation).toBe(1);
+  });
+
+  test("admin presence counts the connected audience device", async ({
+    context,
+  }) => {
+    const admin = await context.newPage();
+    const audience = await context.newPage();
+
+    await admin.goto(ADMIN + "-pres");
+    await admin.waitForFunction(() => !!window.__stage);
+    await audience.goto(AUD + "-pres");
+    await audience.locator("#join-btn").click();
+    await audience.waitForFunction(() => !!window.__stage);
+
+    await expect
+      .poll(
+        async () => Number(await admin.locator("#presence-count").innerText()),
+        {
+          timeout: 4000,
+        },
+      )
+      .toBeGreaterThanOrEqual(1);
+  });
+});

--- a/votive-patina/tests/unit/perf-state.test.mjs
+++ b/votive-patina/tests/unit/perf-state.test.mjs
@@ -1,0 +1,198 @@
+// tests/unit/perf-state.test.mjs
+//
+// Unit tests for the pure performance-state reducer (lib/perf-state.js).
+// Covers US-003: increment, dedupe per device per station, stale-station guard,
+// exactly-one-advance at threshold with decay/threads bump, finale, and reset.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createPerfState,
+  applyPeace,
+  setThreshold,
+  reset,
+  activeStationIndex,
+} from "../../lib/perf-state.js";
+
+// Drive `count` distinct devices through one peace each at the current station.
+function passN(state, count, devicePrefix = "d") {
+  let s = state;
+  for (let i = 0; i < count; i++) {
+    s = applyPeace(s, {
+      deviceId: `${devicePrefix}${i}`,
+      stationIndex: s.stationIndex,
+    });
+  }
+  return s;
+}
+
+test("createPerfState: fresh shape, pristine", () => {
+  const s = createPerfState({ stationCount: 5, threshold: 3 });
+  assert.equal(s.stationCount, 5);
+  assert.equal(s.threshold, 3);
+  assert.equal(s.peaceCount, 0);
+  assert.equal(s.stationIndex, 0);
+  assert.equal(s.decayGen, 0);
+  assert.equal(s.threadsLit, 0);
+  assert.equal(s.passesThisStation, 0);
+  assert.equal(s.finale, false);
+  assert.deepEqual(s.passedDevices, []);
+});
+
+test("createPerfState: defaults to 5 stations, threshold >= 1", () => {
+  const s = createPerfState();
+  assert.equal(s.stationCount, 5);
+  assert.ok(s.threshold >= 1);
+});
+
+test("applyPeace: increments peaceCount and passesThisStation", () => {
+  const s0 = createPerfState({ threshold: 5 });
+  const s1 = applyPeace(s0, { deviceId: "a", stationIndex: 0 });
+  assert.equal(s1.peaceCount, 1);
+  assert.equal(s1.passesThisStation, 1);
+  assert.equal(s1.stationIndex, 0, "below threshold: no advance");
+  assert.equal(s1.decayGen, 0);
+});
+
+test("applyPeace is pure: does not mutate the input state", () => {
+  const s0 = createPerfState({ threshold: 5 });
+  const snapshot = JSON.stringify(s0);
+  applyPeace(s0, { deviceId: "a", stationIndex: 0 });
+  assert.equal(JSON.stringify(s0), snapshot, "input must be unchanged");
+});
+
+test("applyPeace: dedupe per device per station (same device twice = one peace)", () => {
+  let s = createPerfState({ threshold: 5 });
+  s = applyPeace(s, { deviceId: "a", stationIndex: 0 });
+  s = applyPeace(s, { deviceId: "a", stationIndex: 0 }); // duplicate
+  assert.equal(s.peaceCount, 1);
+  assert.equal(s.passesThisStation, 1);
+});
+
+test("applyPeace: a different device at the same station counts", () => {
+  let s = createPerfState({ threshold: 5 });
+  s = applyPeace(s, { deviceId: "a", stationIndex: 0 });
+  s = applyPeace(s, { deviceId: "b", stationIndex: 0 });
+  assert.equal(s.peaceCount, 2);
+  assert.equal(s.passesThisStation, 2);
+});
+
+test("applyPeace: a peace tagged for the wrong station is ignored (stale)", () => {
+  let s = createPerfState({ threshold: 5 });
+  s = applyPeace(s, { deviceId: "a", stationIndex: 3 }); // we are on station 0
+  assert.equal(s.peaceCount, 0);
+  assert.equal(s.passesThisStation, 0);
+});
+
+test("applyPeace: missing deviceId is ignored", () => {
+  const s0 = createPerfState({ threshold: 5 });
+  const s1 = applyPeace(s0, { stationIndex: 0 });
+  assert.equal(s1.peaceCount, 0);
+});
+
+test("threshold crossing advances exactly one station and bumps decay + threads", () => {
+  const threshold = 3;
+  let s = createPerfState({ stationCount: 5, threshold });
+  s = passN(s, threshold); // exactly the threshold
+  assert.equal(s.stationIndex, 1, "advanced exactly one station");
+  assert.equal(s.decayGen, 1, "one generation of decay");
+  assert.equal(s.threadsLit, 1, "one thread lit");
+  assert.equal(s.passesThisStation, 0, "passes reset for the new station");
+  assert.deepEqual(s.passedDevices, [], "device set cleared on advance");
+  assert.equal(
+    s.peaceCount,
+    threshold,
+    "peaceCount is cumulative across the show",
+  );
+});
+
+test("after an advance, the same device may pass again for the NEW station", () => {
+  const threshold = 2;
+  let s = createPerfState({ stationCount: 5, threshold });
+  // device d0 + d1 cross station 0
+  s = applyPeace(s, { deviceId: "d0", stationIndex: 0 });
+  s = applyPeace(s, { deviceId: "d1", stationIndex: 0 });
+  assert.equal(s.stationIndex, 1);
+  // d0 passes again, now for station 1 - allowed
+  s = applyPeace(s, { deviceId: "d0", stationIndex: 1 });
+  assert.equal(s.peaceCount, 3);
+  assert.equal(s.passesThisStation, 1);
+});
+
+test("walking all 5 stations: decayGen 0..5, finale set at the last", () => {
+  const threshold = 4;
+  let s = createPerfState({ stationCount: 5, threshold });
+  const seenDecay = [s.decayGen];
+  for (let station = 0; station < 5; station++) {
+    assert.equal(s.finale, false, `not finale before station ${station + 1}`);
+    s = passN(s, threshold, `s${station}_`);
+    seenDecay.push(s.decayGen);
+  }
+  assert.deepEqual(
+    seenDecay,
+    [0, 1, 2, 3, 4, 5],
+    "decay steps once per station",
+  );
+  assert.equal(s.stationIndex, 5);
+  assert.equal(s.threadsLit, 5, "all threads lit at finale");
+  assert.equal(s.finale, true, "finale set at the last station");
+  assert.equal(activeStationIndex(s), null, "no active station at finale");
+});
+
+test("peaces past the finale are no-ops", () => {
+  const threshold = 1;
+  let s = createPerfState({ stationCount: 5, threshold });
+  s = passN(s, 5, "f"); // 1 each advances 5 stations -> finale
+  assert.equal(s.finale, true);
+  const before = JSON.stringify(s);
+  s = applyPeace(s, { deviceId: "z", stationIndex: 5 });
+  assert.equal(JSON.stringify(s), before, "no change after finale");
+});
+
+test("activeStationIndex tracks the station being prayed", () => {
+  let s = createPerfState({ stationCount: 5, threshold: 1 });
+  assert.equal(activeStationIndex(s), 0);
+  s = applyPeace(s, { deviceId: "a", stationIndex: 0 });
+  assert.equal(activeStationIndex(s), 1);
+});
+
+test("setThreshold updates the threshold and clamps to >= 1", () => {
+  let s = createPerfState({ threshold: 3 });
+  s = setThreshold(s, 7);
+  assert.equal(s.threshold, 7);
+  s = setThreshold(s, 0);
+  assert.equal(s.threshold, 1, "0 clamps to 1");
+  s = setThreshold(s, -5);
+  assert.equal(s.threshold, 1, "negatives clamp to 1");
+});
+
+test("setThreshold change takes effect for the next evaluation, not retroactively", () => {
+  let s = createPerfState({ stationCount: 5, threshold: 5 });
+  s = passN(s, 3); // 3 of 5
+  assert.equal(s.stationIndex, 0);
+  s = setThreshold(s, 3); // lower it; we already have 3 passes this station
+  // The next peace re-evaluates against the new threshold (passes 3 -> 4 >= 3)
+  // but a no-op peace should not advance. A genuinely new device pushes it over.
+  s = applyPeace(s, { deviceId: "extra", stationIndex: 0 });
+  assert.equal(
+    s.stationIndex,
+    1,
+    "crosses the lowered threshold on the next peace",
+  );
+});
+
+test("reset zeroes everything but keeps stationCount and threshold", () => {
+  let s = createPerfState({ stationCount: 5, threshold: 4 });
+  s = passN(s, 4, "x"); // advance once + accumulate
+  s = applyPeace(s, { deviceId: "y", stationIndex: s.stationIndex });
+  const r = reset(s);
+  assert.equal(r.stationCount, 5);
+  assert.equal(r.threshold, 4);
+  assert.equal(r.peaceCount, 0);
+  assert.equal(r.stationIndex, 0);
+  assert.equal(r.decayGen, 0);
+  assert.equal(r.threadsLit, 0);
+  assert.equal(r.passesThisStation, 0);
+  assert.equal(r.finale, false);
+  assert.deepEqual(r.passedDevices, []);
+});

--- a/votive-patina/tests/unit/stations.test.mjs
+++ b/votive-patina/tests/unit/stations.test.mjs
@@ -1,0 +1,96 @@
+// tests/unit/stations.test.mjs
+//
+// Unit tests for the performance score (data/stations.json).
+// Covers US-002: exactly 5 ordered stations with all required fields, arabic[]
+// matching console-prayer.js ARABIC_LINES, valid directions, and a preroll block.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { ARABIC_LINES } from "../../lib/console-prayer.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const stationsPath = path.resolve(__dirname, "../../data/stations.json");
+const data = JSON.parse(fs.readFileSync(stationsPath, "utf8"));
+
+const REQUIRED = [
+  "index",
+  "translit",
+  "arabic",
+  "english",
+  "narration",
+  "prompt",
+  "direction",
+];
+const DIRECTIONS = new Set(["right", "left", "up", "down", "heart"]);
+
+test("stations.json: exactly 5 stations", () => {
+  assert.ok(Array.isArray(data.stations), "stations is an array");
+  assert.equal(data.stations.length, 5);
+});
+
+test("stations.json: indices are 1..5 in order", () => {
+  data.stations.forEach((s, i) => {
+    assert.equal(s.index, i + 1, `station ${i} has index ${i + 1}`);
+  });
+});
+
+test("stations.json: every station has all required, non-empty fields", () => {
+  for (const s of data.stations) {
+    for (const key of REQUIRED) {
+      assert.ok(key in s, `station ${s.index} missing ${key}`);
+      assert.equal(
+        typeof s[key === "index" ? "translit" : key],
+        "string",
+        `station ${s.index} ${key} type`,
+      );
+    }
+    // string fields non-empty
+    for (const key of [
+      "translit",
+      "arabic",
+      "english",
+      "narration",
+      "prompt",
+      "direction",
+    ]) {
+      assert.ok(
+        s[key].trim().length > 0,
+        `station ${s.index} ${key} is non-empty`,
+      );
+    }
+  }
+});
+
+test("stations.json: directions are right/left/up/down/heart, one of each in order", () => {
+  const dirs = data.stations.map((s) => s.direction);
+  for (const d of dirs) assert.ok(DIRECTIONS.has(d), `valid direction: ${d}`);
+  assert.deepEqual(dirs, ["right", "left", "up", "down", "heart"]);
+});
+
+test("stations.json: arabic[] equals console-prayer ARABIC_LINES, in order", () => {
+  const arabic = data.stations.map((s) => s.arabic);
+  assert.deepEqual(arabic, ARABIC_LINES);
+});
+
+test("stations.json: first station is FI KHOUDNIKI KHOUZINA", () => {
+  assert.equal(data.stations[0].translit, "FI KHOUDNIKI KHOUZINA");
+  assert.equal(data.stations[0].arabic, "بحضنك خذينا");
+});
+
+test("stations.json: last station is AMIN (the finale)", () => {
+  assert.equal(data.stations[4].translit, "AMIN");
+  assert.equal(data.stations[4].arabic, "أمين");
+  assert.equal(data.stations[4].direction, "heart");
+});
+
+test("stations.json: preroll has narration + a scan cue", () => {
+  assert.ok(data.preroll, "preroll present");
+  assert.ok(
+    data.preroll.narration.trim().length > 0,
+    "preroll narration non-empty",
+  );
+  assert.match(data.preroll.cue, /scan/i, "preroll cue mentions scanning");
+});


### PR DESCRIPTION
A staged performance layer over the votivepatina piece. Three surfaces sync live over **Supabase Realtime**; the audience (on a Zoom grid) drives the piece by "passing the peace" - one deliberate phone gesture each. Five stations (the prayer lines + Halim's narration + directional prompts); crossing a per-station threshold advances the station, reveals the next on-image translation, lights the next thread of light, and wears the image one JPEG generation - fully worn at "Amin".

## Surfaces
- **Performer** (`/?stage=performer`): the main page in stage mode, a pure renderer - decaying icon, active station (line + narration), five threads lit per completed station, live readout, top-right `[ SHOW QR ] [ ? ]`.
- **Audience** (`/audience`): tap-to-join (grants iOS motion) -> synced image with the station line + prompt as a dismissible on-image overlay; pass-the-peace by motion or the manual button.
- **Admin** (`/admin`): operator console + single authority (owns the reducer) - set N + threshold, begin, reset, presence + live state.

## Notable
- `verify:purity` relaxed to allow ONLY the Supabase client (esm.sh + `*.supabase.co`); every other remote host + analytics still blocked (probe-verified).
- Offline `loopback` transport (BroadcastChannel) makes the realtime sync testable with no network.
- `test:unit` pinned `--test-concurrency=1` (node v25 worker-IPC flake).

## Gates (all green)
53 unit, lint:html (3 pages), verify:purity, **228 e2e** (192 existing with zero regression + 36 new stage; mobile/desktop/reduced-motion). Visually verified audience, admin, performer, QR overlay.

## Remaining (flagged for Halim)
- US-010: move the MAIN-page translation onto the image as a dismissible overlay (the audience already has this).
- US-011 remainder: the subjective main-page "pray for us" button + font polish (needs direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)