### PR TITLE
mother-patina: fix unstyled page on no-trailing-slash URL

### DIFF
--- a/mother-patina/index.html
+++ b/mother-patina/index.html
@@ -11,6 +11,19 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- resolve relative assets (css/js/images) whether or not the URL has a
+         trailing slash, so /mother-patina and /mother-patina/ both work. Must run
+         before the stylesheet/script links below. -->
+    <script>
+      (function () {
+        var p = location.pathname,
+          b;
+        if (p.charAt(p.length - 1) === "/") b = p;
+        else if (/\.[a-z0-9]+$/i.test(p)) b = p.replace(/[^/]*$/, "");
+        else b = p + "/";
+        document.write('<base href="' + b + '">');
+      })();
+    </script>
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"

--- a/mother-patina/tests/e2e/chat.spec.mjs
+++ b/mother-patina/tests/e2e/chat.spec.mjs
@@ -27,6 +27,24 @@ test.describe("mother-patina", () => {
     await expect(page.locator(".phone")).toBeVisible();
   });
 
+  test("a <base> is set so relative assets resolve (with or without a trailing slash)", async ({
+    page,
+  }) => {
+    await page.goto("/?screen=1&fast=1");
+    const baseHref = await page.evaluate(() => {
+      const b = document.querySelector("base");
+      return b ? b.getAttribute("href") : null;
+    });
+    expect(baseHref).toBeTruthy();
+    expect(baseHref.endsWith("/")).toBe(true);
+    // and the stylesheet is genuinely applied (the sr-only h1 is hidden)
+    const cssApplied = await page.evaluate(() => {
+      const h1 = document.querySelector("h1.sr-only");
+      return h1 ? getComputedStyle(h1).position === "absolute" : false;
+    });
+    expect(cssApplied).toBe(true);
+  });
+
   test("screen 1 plays under a date separator, with left/right bubbles", async ({
     page,
   }) => {


### PR DESCRIPTION
The no-slash URL (/mother-patina) served the HTML but relative css/js 404'd at the site root -> unstyled page. Added a dynamic <base href> so assets resolve with or without the slash (and still works served at root locally). Gates green. 🤖 Generated with Claude Code