### PR TITLE
mother-not-metaphor: mobile generative poem (camera + words + morphing illustrations)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -12,6 +12,12 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["--prefix", "votive-patina", "run", "serve"],
       "port": 4178
+    },
+    {
+      "name": "mother-not-metaphor",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["mother-not-metaphor/scripts/serve.mjs"],
+      "port": 4180
     }
   ]
 }

--- a/Assets/images/kitchen-lab/mother-not-metaphor.svg
+++ b/Assets/images/kitchen-lab/mother-not-metaphor.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-label="mother, not metaphor">
+  <rect width="600" height="400" fill="#f3f3f1" />
+  <!-- ocean -->
+  <rect x="36" y="64" width="206" height="150" fill="#2138de" />
+  <!-- sea + war bars -->
+  <rect x="36" y="226" width="206" height="34" fill="#3e8ede" />
+  <rect x="36" y="276" width="206" height="34" fill="#e8381f" />
+  <!-- dough / bread -->
+  <rect x="470" y="60" width="94" height="120" fill="#e9a21c" />
+  <rect x="470" y="206" width="94" height="104" fill="#1e854a" />
+  <!-- the cross (salibon) -->
+  <rect x="330" y="44" width="54" height="292" fill="#141414" />
+  <rect x="286" y="150" width="142" height="54" fill="#141414" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -233,6 +233,16 @@
 
       <div class="lab-section mono">Featured</div>
       <div class="lab-featured">
+        <a class="lab-feature" href="/mother-not-metaphor/">
+          <img
+            class="lab-thumb"
+            src="/Assets/images/kitchen-lab/mother-not-metaphor.svg"
+            alt="Mother, Not Metaphor"
+            loading="lazy"
+          />
+          <div class="lab-feature__name">Mother, Not Metaphor</div>
+          <div class="lab-feature__kind mono">net art</div>
+        </a>
         <a class="lab-feature" href="/curl/">
           <img
             class="lab-thumb"

--- a/mother-not-metaphor/.gitignore
+++ b/mother-not-metaphor/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+test-results/
+playwright-report/
+.playwright/
+*.log
+.DS_Store

--- a/mother-not-metaphor/.htmlvalidate.json
+++ b/mother-not-metaphor/.htmlvalidate.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["html-validate:recommended"],
+  "rules": {
+    "void-style": "off",
+    "doctype-style": "off",
+    "prefer-native-element": [
+      "warn",
+      { "exclude": ["listbox", "presentation"] }
+    ]
+  }
+}

--- a/mother-not-metaphor/Context.md
+++ b/mother-not-metaphor/Context.md
@@ -1,0 +1,53 @@
+# Context - mother, not metaphor
+
+Living memory for this piece. Read on startup.
+
+## What it is
+
+A mobile-native generative poem at `oulipo.xyz/mother-not-metaphor`, featured on
+the Kitchen Lab landing. Five moments / five tongues for one mother. Each moment =
+a layout of three components (camera / words / morphing illustration). Built to be
+a **reusable poem engine** (data + modules) for future poems.
+
+## Decisions (2026-06-22)
+
+- **Camera = hybrid.** Live: viewer's hands drive moment changes via MediaPipe
+  hand tracking. Fallback: timed auto-play when no camera (Instagram in-app
+  browser, denied permission, headless). Default landing shows a "begin" tap so
+  the browser will grant the camera; `?mode=auto` skips it.
+- **Words = scripted typewriter** (not real speech-to-text). Original text exact;
+  English translation fades in beneath non-English lines. Deterministic + offline.
+- **Hand-tracking model = CDN** (MediaPipe). This piece is therefore NOT fully
+  offline like mother-patina/votive-patina; the purity check was relaxed to allow
+  ONLY the MediaPipe CDN + model and still block all analytics/trackers.
+- **Morphing = SVG rects + OKLab color lerp**, pure + unit-tested. No animation
+  framework (brand: vanilla only). Layout transitions use FLIP via the Web
+  Animations API (robust against stuck transforms).
+- **Size = phone-native.** Mobile fills the viewport; wider screens show a 4:5
+  Instagram-portrait card. `overflow:hidden`, no scroll, never overflows.
+- **Fonts = system grotesque + mono** (bulletproof, matches the wireframe). Brand
+  fonts can be layered later if wanted.
+
+## Status: COMPLETE + tested (2026-06-22)
+
+- `npm test` green: 29 unit + html lint + purity + 18 e2e (mobile/desktop/reduced).
+- All 5 layouts + illustrations verified in-browser (screenshots).
+- Featured card added to root `index.html` (first of 3); thumbnail at
+  `Assets/images/kitchen-lab/mother-not-metaphor.svg`.
+- No `vercel.json` change needed (served statically from the folder).
+
+## Open / next
+
+- Real performance footage is optional; live mode uses the viewer's camera.
+- Brand-font layering (Terminal Grotesque / Diatype) not done - system stack ships.
+- Auto mode holds on the last moment (pass `?loop=1` to loop).
+- Could add more layouts (`L6+`) or a second poem to exercise the engine.
+
+## Session State (2026-06-22)
+
+- Task: build the piece end to end. DONE.
+- Files: `mother-not-metaphor/` (index.html, styles.css, src/_, data/poem.json,
+  scripts/_, tests/\*), root `index.html` (Featured card), Assets thumbnail SVG,
+  `.claude/launch.json` (added `mother-not-metaphor` server on 4180).
+- Next steps if resumed: optional brand fonts, optional real footage, optional
+  second poem. Everything currently passes.

--- a/mother-not-metaphor/Context.md
+++ b/mother-not-metaphor/Context.md
@@ -51,3 +51,38 @@ a **reusable poem engine** (data + modules) for future poems.
   `.claude/launch.json` (added `mother-not-metaphor` server on 4180).
 - Next steps if resumed: optional brand fonts, optional real footage, optional
   second poem. Everything currently passes.
+
+## Session State (2026-07-07) - Fragmentary gesture layer + admin
+
+- Task: add deliberate dwell-based gesture control + an on-screen finger HUD, and
+  factor it into a reusable format ("Fragmentary"). DONE.
+- **Dwell + reset gate.** Moment switches are no longer instant on any hand
+  change. A deliberately-formed pose must be held ~1.5s (`dwellMs`, configurable)
+  before it fires, AND only after the hand passed a neutral/absent "reset" since
+  arming/last fire - so a resting or settling hand never advances on its own
+  (fixes a review finding). Interaction: relax, form the shape, hold. A meter
+  fills 0..1 during the hold. The dwell state machine is pure and lives in
+  `src/fragmentary/control.js`.
+- **Finger HUD.** The five finger bars + dwell meter are now on-screen
+  (`#hud-panel`, `fx-*` classes in `src/fragmentary/fragmentary.css`), shown only
+  once live tracking starts (`data-hud="on"` on the stage). `?hud=off` hides it.
+- **Config is data.** Finger-pattern -> action bindings live in
+  `data/gestures.json` (shipped default: open hand -> next, peace sign -> back;
+  bound poses are deliberate shapes so a relaxed/lowered hand stays a neutral).
+- **Admin console (`/admin/`).** Edits bindings + dwell + capture-pose, saves an
+  override to `localStorage`, which the live piece layers over the shipped default
+  via `mergeConfig`. Export JSON to bake as the new `data/gestures.json` default.
+- **Fragmentary = the reusable format.** `src/fragmentary/` (gestures, control,
+  config, hud, css) + `admin/` are meant to be copied into future oulipo pieces.
+  Documented in `FRAGMENTARY.md` (APIs + reuse steps); README updated with the
+  gesture-control section, module table, and `?hud=off` / `/admin/` params.
+- **Files touched here (docs only):** `FRAGMENTARY.md` (new), `README.md`,
+  `Context.md`. The gesture code + `data/gestures.json` + admin were built
+  earlier this session.
+- **Tests (all green).** New unit suites `tests/unit/control.test.mjs` +
+  `tests/unit/config.test.mjs`; `gestures` moved to `src/fragmentary/`
+  (`tests/unit/gestures.test.mjs`, + finger-extension coverage). New e2e
+  `tests/e2e/fragmentary.spec.mjs` drives the dwell + HUD via `window.MNM.feed`
+  with fake clocks. `npm test` = 50 unit + html lint (index + admin) + purity
+  (scans src + admin, still allows only the MediaPipe CDN) + 39 Playwright e2e
+  (piece + fragmentary, on mobile/desktop/reduced-motion).

--- a/mother-not-metaphor/FRAGMENTARY.md
+++ b/mother-not-metaphor/FRAGMENTARY.md
@@ -1,0 +1,310 @@
+# Fragmentary
+
+A small, reusable gesture-control layer for hand-driven web pieces. Fragmentary
+turns a camera + MediaPipe hand tracking into deliberate, dwell-to-act gestures,
+and shows a legible on-screen finger read-out so the viewer can see the machine
+seeing their hand. It was built inside `mother-not-metaphor` but is meant to be
+copied whole into future oulipo pieces - hence its own folder (`src/fragmentary/`)
+and this document.
+
+## Philosophy
+
+- **Deliberate, not twitchy.** A pose does not fire the moment it is recognized.
+  It must be held for a dwell time (~1.5s by default) before it acts. Switches
+  feel intentional and almost never happen by accident.
+- **Legible.** The viewer sees five bars (one per finger) filling with how open
+  each finger is, plus a dwell meter filling toward the action about to fire.
+  The hand-read is honest and visible, not hidden magic.
+- **Data, not code.** What a gesture does is a JSON config (bindings), not
+  hard-coded logic. Ship a default, let an admin console override it, and the
+  poem/piece code never changes.
+- **Pure where it can be.** The reading, the dwell state machine, and the config
+  are DOM-free and Node-testable. Only the HUD touches the DOM; only `hands.js`
+  touches the network (a pinned MediaPipe CDN).
+
+## Module map
+
+All under `src/fragmentary/` except `hands.js` and `camera.js` (the browser I/O),
+which live in `src/`.
+
+### `gestures.js` - hand-shape reading (pure)
+
+Turns MediaPipe's 21 landmarks into what the control and HUD need.
+
+```
+FINGER_NAMES = ['thumb','index','middle','ring','pinky']
+fingersUp(landmarks, handedness='Right') -> [bool x5]      // extended fingers
+fingerExtensions(landmarks) -> [0..1 x5]                   // continuous openness (HUD bars)
+orientation(landmarks) -> 'up'|'down'|'left'|'right'|'none'
+handSignature(landmarks, handedness) -> '01100:up'         // discrete pose string
+handReading(landmarks, handedness) -> {
+  present, up:[bool x5], extensions:[0..1 x5], orientation, signature
+}
+stableSignature(history, n=5) -> signature|null            // last n identical, else null
+signatureChanged(prev, next) -> bool
+```
+
+### `control.js` - the dwell state machine (pure)
+
+Feed it a 5-bool `up` array every frame (or `null` when no hand); it decides when
+a gesture fires.
+
+```
+FINGERS = ['thumb','index','middle','ring','pinky']
+patternKey(up) -> '01100'
+matchBinding(up, binding) -> bool
+bindingSpecificity(binding) -> int          // count of non-'any' constraints
+pickBinding(up, bindings) -> binding|null   // most specific match wins
+createGestureControl({ dwellMs, stableFrames, bindings }) -> {
+  update(up, nowMs) -> { progress, firing, action, binding, stable, candidate, armed, ready },
+  reset(),
+  setConfig(next),   // patch dwellMs / stableFrames / bindings live
+  config             // getter
+}
+```
+
+`update` returns `progress` 0..1 during the hold and `firing:true` on the single
+frame it fires (with `action` = the binding's action). See the state machine
+below.
+
+### `config.js` - validate, merge, persist
+
+```
+STORAGE_KEY = 'fragmentary:mother-not-metaphor'
+FINGERS, ACTIONS = ['next','prev','goto','restart']
+normalizeAction(a), normalizeFingers(f), normalizeBinding(b, i)
+validateConfig(cfg) -> a complete, clamped config (never throws)
+mergeConfig(defaults, override) -> validated config with override layered on top
+loadStored(key?) -> cfg|null      // read the localStorage override
+saveStored(cfg, key?) -> bool     // write it
+clearStored(key?) -> bool         // drop back to the shipped default
+```
+
+`validateConfig` clamps `dwellMs` to 300..6000 and `stableFrames` to 1..15, and
+drops malformed bindings. The `*Stored` helpers no-op safely when there is no
+`localStorage` (e.g. under `node --test`).
+
+### `hud.js` - the on-screen read-out (DOM)
+
+```
+createFingerHud(rootEl, { labels=FINGER_NAMES, reduced=false }) -> {
+  render({ present, up:[bool x5], extensions:[0..1 x5], progress:0..1, label }),
+  flash(),      // brief pulse when a gesture fires (skipped under reduced-motion)
+  destroy()
+}
+```
+
+`render` is called every frame; it fills each finger bar from `extensions`,
+highlights bars where `up` is true, drives the dwell meter from `progress`, and
+writes the action label. It respects `prefers-reduced-motion`.
+
+### `fragmentary.css` - shared styling
+
+The `fx-*` classes used by the HUD (and by the admin console's preview):
+`fx-hud`, `fx-bars`, `fx-bar`, `fx-bar__track`, `fx-bar__fill` (`.is-up`),
+`fx-bar__cap`, `fx-meter`, `fx-meter__fill`, `fx-meter__label`, `fx-flash`. It
+reads `--ink` / `--paper` from the host page (with neutral fallbacks), so the HUD
+inherits the piece's palette. It carries its own reduced-motion rules.
+
+### `src/hands.js`, `src/camera.js` - browser I/O (not pure)
+
+```
+loadHandLandmarker() -> Promise<landmarker>                       // pinned MediaPipe CDN
+trackHands(landmarker, video, onReading) -> stop()               // onReading(reading, raw)
+startCamera(videoEl) -> Promise<stream> ; stopCamera(videoEl)
+```
+
+`onReading` is called with `reading = handReading(...)`. `hands.js` is the only
+off-origin dependency; the purity check allow-lists exactly the MediaPipe hosts.
+
+## Config schema
+
+```json
+{
+  "dwellMs": 1500,
+  "stableFrames": 4,
+  "showHud": true,
+  "bindings": [
+    {
+      "id": "next",
+      "label": "open hand → next",
+      "action": { "type": "next" },
+      "fingers": {
+        "thumb": "up",
+        "index": "up",
+        "middle": "up",
+        "ring": "up",
+        "pinky": "up"
+      }
+    },
+    {
+      "id": "back",
+      "label": "peace sign → back",
+      "action": { "type": "prev" },
+      "fingers": {
+        "thumb": "down",
+        "index": "up",
+        "middle": "up",
+        "ring": "down",
+        "pinky": "down"
+      }
+    }
+  ]
+}
+```
+
+- `dwellMs` - how long a pose is held before it fires (300..6000).
+- `stableFrames` - frames a pose must be identical before it counts as stable
+  (1..15). Higher = steadier but slower to notice.
+- `showHud` - whether the finger HUD is shown (the `?hud=off` query param can
+  still force it off).
+- `bindings[]` - each maps a finger pattern to an action:
+  - `id` - stable identifier.
+  - `label` - shown in the dwell meter while that gesture arms.
+  - `action` - `{ type: 'next'|'prev'|'goto'|'restart', index? }`. `index` is
+    only read for `goto`.
+  - `fingers` - a constraint per finger: `'any'` (ignore), `'up'` (must be
+    extended), `'down'` (must be curled). Fingers you omit default to `'any'`.
+
+Both default bindings are _specific_ poses (`open hand` and `peace sign`), on
+purpose: a relaxed or lowered hand reads as neither, so it counts as a **neutral**
+that never fires and instead acts as the reset (below). Avoid binding a pose the
+hand rests in (e.g. a bare fist ~ a relaxed hand), or a resting hand could match
+it. `pickBinding` still resolves overlaps by specificity (most non-`'any'`
+constraints win), so you can layer a broad and a narrow binding.
+
+## Dwell state machine
+
+`createGestureControl(...).update(up, nowMs)` makes switching **deliberate** - a
+hand that merely appears, settles, or rests never advances on its own:
+
+1. **Stable first.** A pose must be identical for `stableFrames` frames before it
+   is considered. Until then `update` reports idle (`progress: 0`).
+2. **Arm, do not fire, on the first pose.** The first stable pose only arms the
+   machine (`armed:true`), so nothing jumps the instant a hand appears.
+3. **Reset before firing.** A matching pose can only start its dwell once the hand
+   has passed a **reset** since it armed or last fired - i.e. it was absent
+   (`up = null`, key `'none'`) OR held a neutral pose that matches no binding. So
+   the motion is "relax, form the shape, hold". `ready:true` marks a matching pose
+   that has cleared this gate.
+4. **Hold to fire.** Once ready, holding the pose climbs `progress` 0..1 over
+   `dwellMs`; at `progress >= 1` the frame returns `firing:true` with the binding's
+   `action`. The reset is then consumed, so nothing re-fires until the hand resets
+   again.
+5. **Most specific binding wins.** If several bindings match, `pickBinding` picks
+   the one with the most non-`'any'` constraints.
+6. **Relax to repeat.** Because a neutral (unbound) pose is a reset, you do not
+   have to drop the hand out of frame between gestures - just relax it, then form
+   the next shape. A full drop (`'none'`) resets too.
+
+This kills the accidental-advance case where a hand settles into a bound pose and
+just rests there: without a deliberate reset-then-form, it will not fire. Because
+the machine is pure and time is passed in (`nowMs`), it is fully deterministic and
+unit-tested in `tests/unit/control.test.mjs` (including the "resting hand never
+fires" regression).
+
+## The HUD
+
+`createFingerHud(rootEl, ...)` builds five vertical bars plus a horizontal dwell
+meter inside `rootEl`:
+
+- Each **finger bar** fills to that finger's `extension` (0..1). When the finger
+  reads as `up`, the bar (and its cap letter) go full-ink via the `is-up` class.
+- The **dwell meter** (`fx-meter__fill`) fills left-to-right with `progress`, and
+  `fx-meter__label` shows the label of the gesture currently arming.
+- The whole HUD dims when no hand is present (`is-present` toggles opacity) and
+  can `flash()` on a fire.
+
+Every frame you call `hud.render({ present, up, extensions, progress, label })`.
+All styling is in `fragmentary.css`; the piece places the HUD in a
+`#hud-panel` element and toggles visibility with `data-hud="on"|"off"` on the
+stage.
+
+## The admin console (`/admin/`)
+
+A small in-browser tool for tuning gestures without editing code:
+
+- **Edit bindings and dwell.** Add/remove bindings, set each finger to
+  `any`/`up`/`down`, pick the action (`next`/`prev`/`goto`/`restart`, with an
+  index for `goto`), and set `dwellMs` / `stableFrames` / `showHud`.
+- **Capture-pose.** With the camera on, hold a hand shape and capture it - the
+  console reads `fingersUp` and fills a binding's finger constraints from your
+  actual hand, so you design gestures by making them.
+- **Live preview.** The same `fx-*` HUD shows your hand and the dwell meter as you
+  tune, so you feel the timing before you ship it.
+- **Save.** Writes the config to `localStorage` under `STORAGE_KEY` via
+  `saveStored`. The live piece layers this override over the shipped default with
+  `mergeConfig`, so your changes take effect on the next load without a rebuild.
+- **Export JSON.** Emits the validated config so you can paste it into
+  `data/gestures.json` and _bake it as the new shipped default_ (localStorage is
+  per-origin and per-browser; the JSON is the durable, committed source of truth).
+- **Reset.** `clearStored` drops the override and falls back to `data/gestures.json`.
+
+The precedence, everywhere, is: `data/gestures.json` (shipped default) ->
+`mergeConfig` -> localStorage override (admin) -> `?hud=off` (view-time only).
+
+## How to reuse Fragmentary in a new piece
+
+1. **Copy the layer.** Copy `src/fragmentary/` and `admin/` into the new piece,
+   plus `src/hands.js` and `src/camera.js` (the camera + MediaPipe I/O).
+2. **Wire the HUD element + CSS.** Add a `<div id="hud-panel">` to the page and
+   `<link rel="stylesheet" href="src/fragmentary/fragmentary.css">` in the head.
+   Give the page `--ink` / `--paper` custom properties so the HUD inherits your
+   palette.
+3. **Ship a default config.** Create `data/gestures.json` with your `dwellMs`,
+   `stableFrames`, `showHud`, and `bindings`. Change `STORAGE_KEY` in `config.js`
+   to your piece's name so its localStorage override does not collide.
+4. **Load + merge the config** like `src/main.js` does:
+
+   ```js
+   import {
+     validateConfig,
+     mergeConfig,
+     loadStored,
+   } from "./fragmentary/config.js";
+   const defaults = await (await fetch("data/gestures.json")).json();
+   const gestureConfig = mergeConfig(validateConfig(defaults), loadStored());
+   ```
+
+5. **Create the control + HUD:**
+
+   ```js
+   import { createGestureControl } from "./fragmentary/control.js";
+   import { createFingerHud } from "./fragmentary/hud.js";
+   const control = createGestureControl({
+     dwellMs: gestureConfig.dwellMs,
+     stableFrames: gestureConfig.stableFrames,
+     bindings: gestureConfig.bindings,
+   });
+   const hud = createFingerHud(document.getElementById("hud-panel"), {
+     reduced,
+   });
+   ```
+
+6. **Feed readings every frame.** Start the camera and hand tracking, and on each
+   reading call `control.update(reading.present ? reading.up : null, now)`, render
+   the HUD, and dispatch the action when `firing`. In `mother-not-metaphor` this
+   lives behind `player.feed(reading, now)`, which calls `control.update`, calls
+   `hud.render`, and maps `action.type` to `next` / `prev` / `goto` / `restart`.
+
+   ```js
+   const { loadHandLandmarker, trackHands } = await import("./hands.js");
+   const landmarker = await loadHandLandmarker();
+   trackHands(landmarker, videoEl, (reading) =>
+     player.feed(reading, performance.now()),
+   );
+   ```
+
+7. **Show the HUD when live.** Keep `data-hud="off"` on the stage until hand
+   tracking actually starts, then set `data-hud="on"` (respecting `showHud` and
+   `?hud=off`) so the read-out only appears when there is a camera to read.
+
+That is the whole contract. New piece = new `data/gestures.json` + a few lines of
+wiring; the reading, dwell, HUD, and admin console come along unchanged.
+
+## Tests
+
+The pure modules are unit-tested with `node --test`:
+`tests/unit/gestures.test.mjs`, `tests/unit/control.test.mjs`,
+`tests/unit/config.test.mjs`. The DOM path (HUD, feed loop) is covered by the
+piece's Playwright suite. Run everything with `npm test`.

--- a/mother-not-metaphor/README.md
+++ b/mother-not-metaphor/README.md
@@ -1,0 +1,88 @@
+# mother, not metaphor
+
+A mobile-native generative poem at `oulipo.xyz/mother-not-metaphor`. Five moments,
+five tongues (EN / FR / AR-romanized / AR-Levantine / PT-BR) for one mother. Each
+moment is a layout of three components - a **camera** (the performer), the
+**words** (revealed like live transcription, with an English translation), and a
+flat-geometric **illustration** that morphs, paced to speech.
+
+The piece is also a **reusable poem engine**: the whole thing is data
+(`data/poem.json`) driven by a small set of modules. New poems = new JSON + new
+keyframes, same machine.
+
+## Run it
+
+```bash
+npm install            # @playwright/test + html-validate (dev only)
+npm run serve          # static server on http://localhost:4180
+npm test               # unit + html lint + purity + e2e
+```
+
+Useful URLs while developing:
+
+- `/?mode=auto` - skip the start tap, play the timed (no-camera) version
+- `/?mode=live` - force the camera + hand-tracking path
+- `/?speed=8` - speed timing up (tests / impatience)
+- `/?loop=1` - loop after the last moment
+
+In the console, `window.MNM` exposes `state()`, `next()`, `goTo(i)`, and
+`still(i, k)` (freeze on moment `i`, keyframe `k`) for debugging.
+
+## How it works
+
+| concern                                  | where                          | tested by                      |
+| ---------------------------------------- | ------------------------------ | ------------------------------ |
+| perceptual color blends (OKLab)          | `src/color.js`                 | `tests/unit/color.test.mjs`    |
+| rectangle frame morphing + count padding | `src/morph.js`                 | `tests/unit/morph.test.mjs`    |
+| speaking-rate timing                     | `src/pacing.js`                | `tests/unit/pacing.test.mjs`   |
+| hand-shape signatures                    | `src/gestures.js`              | `tests/unit/gestures.test.mjs` |
+| poem data shape                          | `data/poem.json`               | `tests/unit/poem.test.mjs`     |
+| SVG illustration renderer                | `src/illustration.js`          | e2e                            |
+| typewriter words                         | `src/words.js`                 | e2e                            |
+| layouts + FLIP transitions               | `src/layout.js`                | e2e                            |
+| camera                                   | `src/camera.js`                | e2e (fallback path)            |
+| MediaPipe hand tracking                  | `src/hands.js`                 | live only                      |
+| orchestration                            | `src/player.js`, `src/main.js` | e2e                            |
+
+The four pure modules (`color`, `morph`, `pacing`, `gestures`) are DOM-free so
+Node can unit-test the logic directly. Everything that touches the DOM is covered
+by Playwright (mobile + desktop + reduced-motion).
+
+### Morphing
+
+Every illustration frame is an array of cells (rectangles). To go from one frame
+to the next we pad to a common cell count (extra cells are born from / die into a
+point), interpolate geometry linearly, and interpolate color through **OKLab** so
+blue->red passes through vivid purples instead of grey mud. A single
+`requestAnimationFrame` loop runs the active tween with an ease-in-out curve.
+
+### Transitions
+
+- **Between moments** (which layout is shown): a stable change in the performer's
+  hand shape (MediaPipe Hand Landmarker) advances one moment. With no camera it
+  auto-advances on a timer paced to the line.
+- **Within a moment** (illustration keyframes): time-paced across the moment's
+  spoken duration (`pacing.js`).
+
+### One external dependency
+
+Hand tracking loads MediaPipe `tasks-vision` + the hand-landmarker model from a
+CDN (pinned in `src/hands.js`). `scripts/verify-purity.mjs` allows ONLY those two
+hosts and blocks all analytics/trackers. If the CDN is blocked or offline, the
+piece silently falls back to auto-play.
+
+## Add a new poem
+
+1. Copy this folder (or point a new `index.html` at the same `src/`).
+2. Write a new `data/poem.json`:
+   - `palette` - named colors (`#rrggbb`).
+   - `pacing` - `msPerChar`, `minMomentMs`, `maxMomentMs`, `morphMs`.
+   - `moments[]` - each with `lang`, `layout` (`L1`..`L5`), `original`, `english`
+     (for non-English), and `illustration.keyframes`.
+3. Each keyframe is an array of cells `{ x, y, w, h, fill, o }` in a `0..100`
+   viewBox; `fill` is a palette key. Keep the cell **count and order consistent
+   within a moment** so frames morph cleanly; counts can differ across moments
+   (cells fade in/out).
+4. Add or adjust layouts in `styles.css` (`.stage[data-layout="L_"]`) if you need
+   arrangements beyond the five.
+5. `npm test`.

--- a/mother-not-metaphor/README.md
+++ b/mother-not-metaphor/README.md
@@ -24,29 +24,45 @@ Useful URLs while developing:
 - `/?mode=live` - force the camera + hand-tracking path
 - `/?speed=8` - speed timing up (tests / impatience)
 - `/?loop=1` - loop after the last moment
+- `/?hud=off` - hide the on-screen finger read-out (clean capture)
+- `/admin/` - the gesture-control console (edit bindings + dwell time)
 
-In the console, `window.MNM` exposes `state()`, `next()`, `goTo(i)`, and
-`still(i, k)` (freeze on moment `i`, keyframe `k`) for debugging.
+In the console, `window.MNM` exposes `state()`, `next()`, `goTo(i)`,
+`still(i, k)` (freeze on moment `i`, keyframe `k`), and `feed(reading, now?)`
+(inject a hand reading through the gesture control) for debugging, plus `config`
+(the resolved gesture config) and `poem`.
 
 ## How it works
 
-| concern                                  | where                          | tested by                      |
-| ---------------------------------------- | ------------------------------ | ------------------------------ |
-| perceptual color blends (OKLab)          | `src/color.js`                 | `tests/unit/color.test.mjs`    |
-| rectangle frame morphing + count padding | `src/morph.js`                 | `tests/unit/morph.test.mjs`    |
-| speaking-rate timing                     | `src/pacing.js`                | `tests/unit/pacing.test.mjs`   |
-| hand-shape signatures                    | `src/gestures.js`              | `tests/unit/gestures.test.mjs` |
-| poem data shape                          | `data/poem.json`               | `tests/unit/poem.test.mjs`     |
-| SVG illustration renderer                | `src/illustration.js`          | e2e                            |
-| typewriter words                         | `src/words.js`                 | e2e                            |
-| layouts + FLIP transitions               | `src/layout.js`                | e2e                            |
-| camera                                   | `src/camera.js`                | e2e (fallback path)            |
-| MediaPipe hand tracking                  | `src/hands.js`                 | live only                      |
-| orchestration                            | `src/player.js`, `src/main.js` | e2e                            |
+| concern                                  | where                          | tested by                    |
+| ---------------------------------------- | ------------------------------ | ---------------------------- |
+| perceptual color blends (OKLab)          | `src/color.js`                 | `tests/unit/color.test.mjs`  |
+| rectangle frame morphing + count padding | `src/morph.js`                 | `tests/unit/morph.test.mjs`  |
+| speaking-rate timing                     | `src/pacing.js`                | `tests/unit/pacing.test.mjs` |
+| poem data shape                          | `data/poem.json`               | `tests/unit/poem.test.mjs`   |
+| SVG illustration renderer                | `src/illustration.js`          | e2e                          |
+| typewriter words                         | `src/words.js`                 | e2e                          |
+| layouts + FLIP transitions               | `src/layout.js`                | e2e                          |
+| camera                                   | `src/camera.js`                | e2e (fallback path)          |
+| MediaPipe hand tracking                  | `src/hands.js`                 | live only                    |
+| orchestration                            | `src/player.js`, `src/main.js` | e2e                          |
 
-The four pure modules (`color`, `morph`, `pacing`, `gestures`) are DOM-free so
-Node can unit-test the logic directly. Everything that touches the DOM is covered
-by Playwright (mobile + desktop + reduced-motion).
+The **Fragmentary** gesture layer (its own reusable folder - see below):
+
+| concern                           | where                             | tested by                      |
+| --------------------------------- | --------------------------------- | ------------------------------ |
+| hand-shape reading + signatures   | `src/fragmentary/gestures.js`     | `tests/unit/gestures.test.mjs` |
+| dwell-to-act state machine        | `src/fragmentary/control.js`      | `tests/unit/control.test.mjs`  |
+| config validate / merge / persist | `src/fragmentary/config.js`       | `tests/unit/config.test.mjs`   |
+| on-screen finger HUD              | `src/fragmentary/hud.js`          | e2e                            |
+| HUD styling (`fx-*`)              | `src/fragmentary/fragmentary.css` | e2e                            |
+| shipped default gesture config    | `data/gestures.json`              | `tests/unit/config.test.mjs`   |
+| gesture-tuning console            | `admin/`                          | manual                         |
+
+The pure modules (`color`, `morph`, `pacing`, and the Fragmentary
+`gestures` / `control` / `config`) are DOM-free so Node can unit-test the logic
+directly. Everything that touches the DOM is covered by Playwright (mobile +
+desktop + reduced-motion).
 
 ### Morphing
 
@@ -58,11 +74,38 @@ blue->red passes through vivid purples instead of grey mud. A single
 
 ### Transitions
 
-- **Between moments** (which layout is shown): a stable change in the performer's
-  hand shape (MediaPipe Hand Landmarker) advances one moment. With no camera it
-  auto-advances on a timer paced to the line.
+- **Between moments** (which layout is shown): the performer relaxes, forms a
+  deliberate hand shape, and holds it for the dwell time (~1.5s) to advance (see
+  Gesture control). With no camera it auto-advances on a timer paced to the line.
 - **Within a moment** (illustration keyframes): time-paced across the moment's
   spoken duration (`pacing.js`).
+
+### Gesture control (Fragmentary)
+
+Live hand input runs through **Fragmentary**, a small reusable gesture-control
+layer in `src/fragmentary/` (copied into future pieces - see
+[`FRAGMENTARY.md`](FRAGMENTARY.md)).
+
+- **Dwell, not twitch.** A pose does not act the instant it is recognized. It
+  must be held for `dwellMs` (~1.5s by default, configurable) before it fires, and
+  only after the hand has passed a neutral/absent "reset" - so a resting or
+  settling hand never advances on its own. During the hold a meter fills 0..1.
+  In short: relax, form the shape, hold.
+- **The finger HUD.** A small on-screen read-out (`#hud-panel`) shows five bars,
+  one per finger, filling with how open each finger is and highlighting the ones
+  read as "up", plus the dwell meter and the action label. It only appears once
+  live hand tracking starts (`data-hud="on"` on the stage). Pass `?hud=off` to
+  hide it for a clean capture.
+- **Configurable bindings.** What a gesture does is data: `data/gestures.json`
+  maps finger patterns (`thumb..pinky : any|up|down`) to actions
+  (`next`/`prev`/`goto`/`restart`). The shipped default is "open hand -> next,
+  peace sign -> back" (a relaxed hand is the neutral reset). Edit it live at
+  **`/admin/`** (the gesture console),
+  which saves an override to `localStorage`; the piece layers that over the
+  shipped default with `mergeConfig`. Export the JSON from the console to bake it
+  as the new default in `data/gestures.json`.
+
+Full API and reuse guide: [`FRAGMENTARY.md`](FRAGMENTARY.md).
 
 ### One external dependency
 

--- a/mother-not-metaphor/admin/admin.css
+++ b/mother-not-metaphor/admin/admin.css
@@ -1,0 +1,462 @@
+/*
+ * admin.css - Fragmentary gesture console. De Stijl neutrals, hairline borders,
+ * no rounded corners / shadows / gradients. Two columns on desktop (live left,
+ * editor right); one column on mobile. Utilitarian, on-brand.
+ */
+
+:root {
+  --paper: #f3f3f1;
+  --ink: #141414;
+  --line: rgba(20, 20, 20, 0.85);
+  --line-soft: rgba(20, 20, 20, 0.28);
+  --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --sans: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  line-height: 1.4;
+  -webkit-font-smoothing: antialiased;
+}
+
+.mono {
+  font-family: var(--mono);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* --- header ------------------------------------------------------------ */
+.head {
+  padding: 20px 20px 12px;
+  border-bottom: 1px solid var(--line);
+}
+.head__title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+.head__sub {
+  margin: 4px 0 0;
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+/* --- layout ------------------------------------------------------------ */
+.cols {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  align-items: start;
+}
+@media (min-width: 860px) {
+  .cols {
+    grid-template-columns: minmax(300px, 380px) 1fr;
+  }
+  .panel--live {
+    border-right: 1px solid var(--line);
+  }
+}
+
+.panel {
+  padding: 18px 20px 24px;
+}
+.panel + .panel {
+  border-top: 1px solid var(--line);
+}
+@media (min-width: 860px) {
+  .panel + .panel {
+    border-top: 0;
+  }
+}
+.panel__h {
+  margin: 0 0 12px;
+  font-size: 12px;
+  font-family: var(--mono);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  opacity: 0.65;
+}
+
+/* --- camera ------------------------------------------------------------ */
+.cam {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  border: 1px solid var(--line);
+  background: rgba(20, 20, 20, 0.04);
+  overflow: hidden;
+}
+.cam__video {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1);
+  background: rgba(20, 20, 20, 0.06);
+}
+.cam__msg {
+  position: absolute;
+  left: 8px;
+  bottom: 8px;
+  right: 8px;
+  margin: 0;
+  padding: 4px 6px;
+  font-size: 11px;
+  background: var(--paper);
+  border: 1px solid var(--line-soft);
+}
+
+.hud-wrap {
+  margin-top: 14px;
+}
+
+/* --- readout ----------------------------------------------------------- */
+.readout {
+  margin: 14px 0 0;
+  font-size: 12px;
+}
+.readout__row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--line-soft);
+}
+.readout dt {
+  opacity: 0.6;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 10px;
+}
+.readout dd {
+  margin: 0;
+  text-align: right;
+  word-break: break-all;
+}
+.readout__fire.is-active {
+  font-weight: 700;
+  background: var(--ink);
+  color: var(--paper);
+  padding: 0 4px;
+}
+
+.note {
+  margin: 12px 0 0;
+  font-size: 11px;
+  opacity: 0.6;
+  line-height: 1.5;
+}
+
+/* --- fields ------------------------------------------------------------ */
+.field {
+  margin: 0 0 18px;
+}
+.field__label {
+  display: block;
+  font-size: 12px;
+  margin-bottom: 6px;
+  letter-spacing: 0.02em;
+}
+.field__val {
+  opacity: 0.6;
+}
+.field__range {
+  width: 100%;
+  height: 44px;
+  accent-color: var(--ink);
+  cursor: pointer;
+}
+.field__num {
+  width: 72px;
+  height: 44px;
+  padding: 0 8px;
+  font-family: var(--mono);
+  font-size: 14px;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line);
+}
+.field--inline {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  align-items: center;
+  gap: 10px;
+}
+.field--inline .field__label {
+  margin-bottom: 0;
+}
+.field--inline .field__hint {
+  margin: 0;
+}
+.field__hint {
+  margin: 6px 0 0;
+  font-size: 11px;
+  opacity: 0.55;
+}
+
+/* --- bindings ---------------------------------------------------------- */
+.bindings {
+  margin-top: 6px;
+  border-top: 1px solid var(--line);
+  padding-top: 16px;
+}
+.bindings__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+.bindings__h {
+  margin: 0;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  opacity: 0.65;
+}
+.bindings__actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.bindings__legend {
+  margin: 10px 0 0;
+  font-size: 10px;
+  opacity: 0.5;
+  letter-spacing: 0.04em;
+}
+
+.binding-list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+}
+.binding {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line-soft);
+}
+.binding--empty {
+  display: block;
+  font-size: 11px;
+  opacity: 0.5;
+  padding: 10px 0;
+}
+
+.binding__fingers {
+  display: flex;
+  gap: 3px;
+}
+.finger-toggle {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 2px 4px;
+  font-family: var(--mono);
+  font-size: 10px;
+  line-height: 1.2;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line-soft);
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+.finger-toggle:hover {
+  opacity: 0.7;
+}
+.finger-toggle[data-state="up"] {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+.finger-toggle[data-state="down"] {
+  border-color: var(--line);
+  border-style: dashed;
+}
+
+.binding__action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.binding__select {
+  height: 44px;
+  padding: 0 8px;
+  font-size: 13px;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line);
+  cursor: pointer;
+}
+.binding__goto {
+  width: 64px;
+  height: 44px;
+  padding: 0 6px;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line);
+}
+
+.binding__labelwrap {
+  min-width: 0;
+}
+.binding__label {
+  width: 100%;
+  height: 44px;
+  padding: 0 8px;
+  font-family: var(--sans);
+  font-size: 13px;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line-soft);
+}
+.binding__label:focus,
+.binding__select:focus,
+.binding__goto:focus,
+.field__num:focus {
+  outline: 2px solid var(--ink);
+  outline-offset: -2px;
+}
+
+.binding__del {
+  white-space: nowrap;
+}
+
+@media (max-width: 620px) {
+  .binding {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+  .binding__fingers {
+    flex-wrap: wrap;
+  }
+}
+
+/* --- buttons ----------------------------------------------------------- */
+.controls-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 12px;
+}
+.controls-row--save {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+}
+.btn {
+  min-height: 44px;
+  padding: 0 16px;
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line);
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+.btn:hover {
+  opacity: 0.7;
+}
+.btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+.btn--primary {
+  background: var(--ink);
+  color: var(--paper);
+}
+.btn--sm {
+  min-height: 36px;
+  padding: 0 12px;
+  font-size: 12px;
+}
+.btn:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 2px;
+}
+
+/* --- save note + export ------------------------------------------------ */
+.save-note,
+#save-note {
+  margin: 10px 0 0;
+  font-size: 12px;
+  min-height: 1.2em;
+}
+#save-note.is-flash {
+  animation: note-flash 0.5s ease;
+}
+@keyframes note-flash {
+  0% {
+    opacity: 0.2;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.export {
+  margin-top: 16px;
+  border: 1px solid var(--line);
+}
+.export__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--line-soft);
+}
+.export__head .field__label {
+  margin: 0;
+}
+.export__text {
+  display: block;
+  width: 100%;
+  padding: 12px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--ink);
+  background: var(--paper);
+  border: 0;
+  resize: vertical;
+}
+.export__text:focus {
+  outline: 2px solid var(--ink);
+  outline-offset: -2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn,
+  .finger-toggle {
+    transition: none;
+  }
+  #save-note.is-flash {
+    animation: none;
+  }
+}

--- a/mother-not-metaphor/admin/admin.js
+++ b/mother-not-metaphor/admin/admin.js
@@ -1,0 +1,489 @@
+/**
+ * admin/admin.js - the Fragmentary gesture console (dev/config tool).
+ *
+ * Edits a Fragmentary config live: which finger pattern turns the page, and how
+ * long a pose is held (dwell). It renders the finger HUD from a real camera so
+ * the performer can SEE the hand being read and capture a pose physically, then
+ * SAVE (to localStorage, which the live piece layers on next load) and EXPORT
+ * the JSON to bake into data/gestures.json.
+ *
+ * Nothing here is piece-specific except the storage key and the goto range,
+ * both read from the shipped defaults + poem. Reuse it for the next piece by
+ * pointing it at that piece's gestures.json / poem.json.
+ */
+
+import {
+  STORAGE_KEY,
+  FINGERS,
+  ACTIONS,
+  validateConfig,
+  mergeConfig,
+  loadStored,
+  saveStored,
+  clearStored,
+} from "../src/fragmentary/config.js";
+import {
+  createGestureControl,
+  patternKey,
+} from "../src/fragmentary/control.js";
+import { createFingerHud } from "../src/fragmentary/hud.js";
+import { startCamera, stopCamera } from "../src/camera.js";
+import { loadHandLandmarker, trackHands } from "../src/hands.js";
+
+const FINGER_CAPS = ["T", "I", "M", "R", "P"];
+const CONSTRAINTS = ["any", "up", "down"];
+const CONSTRAINT_GLYPH = { any: "-", up: "up", down: "down" };
+
+const $ = (id) => document.getElementById(id);
+
+const els = {
+  storageKey: $("storage-key"),
+  video: $("cam-video"),
+  camMsg: $("cam-msg"),
+  startCam: $("start-cam"),
+  stopCam: $("stop-cam"),
+  hudWrap: $("hud-wrap"),
+  roPattern: $("ro-pattern"),
+  roMatched: $("ro-matched"),
+  roFire: $("ro-fire"),
+  dwell: $("dwell"),
+  dwellVal: $("dwell-val"),
+  stableFrames: $("stable-frames"),
+  bindingList: $("binding-list"),
+  capturePose: $("capture-pose"),
+  addBinding: $("add-binding"),
+  save: $("save"),
+  export: $("export"),
+  reset: $("reset"),
+  saveNote: $("save-note"),
+  exportBox: $("export-box"),
+  exportJson: $("export-json"),
+  copyJson: $("copy-json"),
+};
+
+// --- state ---------------------------------------------------------------
+let working = null; // the config being edited
+let control = null; // dwell state machine (mirrors `working`)
+let hud = null; // finger HUD renderer
+let momentCount = 5; // goto range (poem.moments.length), fallback 5
+let lastReading = null; // most recent live hand reading, for "capture pose"
+let stopTracking = null; // trackHands() disposer
+let fireTimer = null; // clears the transient "would fire" note
+
+// --- boot ----------------------------------------------------------------
+async function boot() {
+  els.storageKey.textContent = STORAGE_KEY;
+
+  const [defaults, moments] = await Promise.all([
+    fetchDefaults(),
+    fetchMomentCount(),
+  ]);
+  momentCount = moments;
+
+  const override = loadStored();
+  working = mergeConfig(defaults, override);
+
+  control = createGestureControl({
+    dwellMs: working.dwellMs,
+    stableFrames: working.stableFrames,
+    bindings: working.bindings,
+  });
+  hud = createFingerHud(els.hudWrap, {
+    reduced: window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  });
+  hud.render({});
+
+  populate();
+  wireEvents();
+}
+
+async function fetchDefaults() {
+  try {
+    const r = await fetch("../data/gestures.json");
+    if (!r.ok) throw new Error(String(r.status));
+    return validateConfig(await r.json());
+  } catch {
+    // fall back to the library defaults so the editor still works offline
+    return validateConfig({});
+  }
+}
+
+async function fetchMomentCount() {
+  try {
+    const r = await fetch("../data/poem.json");
+    if (!r.ok) throw new Error(String(r.status));
+    const poem = await r.json();
+    const n = Array.isArray(poem.moments) ? poem.moments.length : 0;
+    return n > 0 ? n : 5;
+  } catch {
+    return 5;
+  }
+}
+
+// --- populate UI from `working` -----------------------------------------
+function populate() {
+  els.dwell.value = String(working.dwellMs);
+  els.dwellVal.textContent = secs(working.dwellMs);
+  els.stableFrames.value = String(working.stableFrames);
+  renderBindings();
+}
+
+function secs(ms) {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+// --- bindings editor -----------------------------------------------------
+function renderBindings() {
+  els.bindingList.replaceChildren();
+  if (!working.bindings.length) {
+    const empty = document.createElement("li");
+    empty.className = "binding binding--empty mono";
+    empty.textContent = "no bindings - add one, or capture a pose";
+    els.bindingList.appendChild(empty);
+    return;
+  }
+  working.bindings.forEach((binding, index) => {
+    els.bindingList.appendChild(bindingRow(binding, index));
+  });
+}
+
+function bindingRow(binding, index) {
+  const li = document.createElement("li");
+  li.className = "binding";
+
+  // finger constraint toggles
+  const fingers = document.createElement("div");
+  fingers.className = "binding__fingers";
+  FINGERS.forEach((name, i) => {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "finger-toggle";
+    const state = binding.fingers[name] || "any";
+    applyFingerToggle(btn, name, i, state);
+    btn.addEventListener("click", () => {
+      const next =
+        CONSTRAINTS[(CONSTRAINTS.indexOf(binding.fingers[name]) + 1) % 3];
+      binding.fingers[name] = next;
+      applyFingerToggle(btn, name, i, next);
+      syncControl();
+    });
+    fingers.appendChild(btn);
+  });
+
+  // action select
+  const actionWrap = document.createElement("div");
+  actionWrap.className = "binding__action";
+  const selId = `action-${index}`;
+  const selLabel = document.createElement("label");
+  selLabel.className = "sr-only";
+  selLabel.setAttribute("for", selId);
+  selLabel.textContent = `binding ${index + 1} action`;
+  const sel = document.createElement("select");
+  sel.className = "binding__select mono";
+  sel.id = selId;
+  ACTIONS.forEach((a) => {
+    const opt = document.createElement("option");
+    opt.value = a;
+    opt.textContent = a;
+    if (a === binding.action.type) opt.selected = true;
+    sel.appendChild(opt);
+  });
+
+  // goto index (shown only when action === goto)
+  const gotoId = `goto-${index}`;
+  const gotoLabel = document.createElement("label");
+  gotoLabel.className = "sr-only";
+  gotoLabel.setAttribute("for", gotoId);
+  gotoLabel.textContent = `binding ${index + 1} moment index`;
+  const gotoInput = document.createElement("input");
+  gotoInput.type = "number";
+  gotoInput.id = gotoId;
+  gotoInput.className = "binding__goto mono";
+  gotoInput.min = "0";
+  gotoInput.max = String(Math.max(0, momentCount - 1));
+  gotoInput.step = "1";
+  gotoInput.value = String(binding.action.index || 0);
+  gotoInput.hidden = binding.action.type !== "goto";
+  gotoInput.addEventListener("input", () => {
+    binding.action.index = clampInt(gotoInput.value, 0, momentCount - 1);
+  });
+
+  sel.addEventListener("change", () => {
+    binding.action.type = sel.value;
+    if (sel.value === "goto") {
+      if (typeof binding.action.index !== "number") binding.action.index = 0;
+      gotoInput.value = String(binding.action.index);
+      gotoInput.hidden = false;
+    } else {
+      delete binding.action.index;
+      gotoInput.hidden = true;
+    }
+    syncControl();
+  });
+  actionWrap.append(selLabel, sel, gotoLabel, gotoInput);
+
+  // label text
+  const labelId = `label-${index}`;
+  const labWrap = document.createElement("div");
+  labWrap.className = "binding__labelwrap";
+  const labFor = document.createElement("label");
+  labFor.className = "sr-only";
+  labFor.setAttribute("for", labelId);
+  labFor.textContent = `binding ${index + 1} label`;
+  const labInput = document.createElement("input");
+  labInput.type = "text";
+  labInput.id = labelId;
+  labInput.className = "binding__label";
+  labInput.placeholder = "label";
+  labInput.value = binding.label || "";
+  labInput.addEventListener("input", () => {
+    binding.label = labInput.value;
+  });
+  labWrap.append(labFor, labInput);
+
+  // delete
+  const del = document.createElement("button");
+  del.type = "button";
+  del.className = "btn btn--sm binding__del";
+  del.textContent = "Delete";
+  del.addEventListener("click", () => {
+    working.bindings.splice(index, 1);
+    renderBindings();
+    syncControl();
+  });
+
+  li.append(fingers, actionWrap, labWrap, del);
+  return li;
+}
+
+function applyFingerToggle(btn, name, i, state) {
+  btn.dataset.state = state;
+  btn.textContent = `${FINGER_CAPS[i]} ${CONSTRAINT_GLYPH[state]}`;
+  btn.setAttribute("aria-label", `${name}: ${state === "any" ? "any" : state}`);
+  btn.title = `${name}: ${state}`;
+}
+
+function clampInt(v, lo, hi) {
+  const n = Math.round(Number(v));
+  if (!Number.isFinite(n)) return lo;
+  return Math.min(hi, Math.max(lo, n));
+}
+
+// --- keep control in step with the working config ------------------------
+function syncControl() {
+  control.setConfig({
+    dwellMs: working.dwellMs,
+    stableFrames: working.stableFrames,
+    bindings: working.bindings,
+  });
+  control.reset();
+}
+
+// --- events --------------------------------------------------------------
+function wireEvents() {
+  els.dwell.addEventListener("input", () => {
+    working.dwellMs = clampInt(els.dwell.value, 300, 4000);
+    els.dwellVal.textContent = secs(working.dwellMs);
+    control.setConfig({ dwellMs: working.dwellMs });
+  });
+
+  els.stableFrames.addEventListener("input", () => {
+    working.stableFrames = clampInt(els.stableFrames.value, 1, 10);
+    control.setConfig({ stableFrames: working.stableFrames });
+  });
+
+  els.addBinding.addEventListener("click", () => {
+    working.bindings.push({
+      id: `b${working.bindings.length}`,
+      label: "",
+      action: { type: "next" },
+      fingers: fingersFromConstraint("any"),
+    });
+    renderBindings();
+    syncControl();
+  });
+
+  els.capturePose.addEventListener("click", capturePose);
+  els.startCam.addEventListener("click", startLive);
+  els.stopCam.addEventListener("click", stopLive);
+  els.save.addEventListener("click", doSave);
+  els.export.addEventListener("click", doExport);
+  els.reset.addEventListener("click", doReset);
+  els.copyJson.addEventListener("click", doCopy);
+}
+
+function fingersFromConstraint(c) {
+  const out = {};
+  for (const name of FINGERS) out[name] = c;
+  return out;
+}
+
+function capturePose() {
+  if (!lastReading || !lastReading.present) {
+    flashNote(
+      els.saveNote,
+      "no hand seen - start the camera and hold a pose, then capture",
+    );
+    return;
+  }
+  const up = lastReading.up;
+  const fingers = {};
+  FINGERS.forEach((name, i) => {
+    fingers[name] = up[i] ? "up" : "down";
+  });
+  working.bindings.push({
+    id: `b${working.bindings.length}`,
+    label: `captured ${patternKey(up)}`,
+    action: { type: "next" },
+    fingers,
+  });
+  renderBindings();
+  syncControl();
+  flashNote(els.saveNote, `captured pose ${patternKey(up)}`);
+}
+
+// --- camera + tracking ---------------------------------------------------
+async function startLive() {
+  els.startCam.disabled = true;
+  setCamMsg("starting camera…");
+  try {
+    await startCamera(els.video);
+  } catch {
+    setCamMsg("camera denied or unavailable - the editor still works");
+    els.startCam.disabled = false;
+    return;
+  }
+  setCamMsg("loading hand tracking…");
+  let landmarker;
+  try {
+    landmarker = await loadHandLandmarker();
+  } catch {
+    setCamMsg("hand tracking failed to load - video only, no pose reading");
+    els.stopCam.disabled = false;
+    return;
+  }
+  setCamMsg("tracking - hold a hand shape");
+  els.stopCam.disabled = false;
+  control.reset();
+  stopTracking = trackHands(landmarker, els.video, onReading);
+}
+
+function stopLive() {
+  if (stopTracking) {
+    stopTracking();
+    stopTracking = null;
+  }
+  stopCamera(els.video);
+  lastReading = null;
+  control.reset();
+  hud.render({});
+  els.roPattern.textContent = "-----";
+  els.roMatched.textContent = "none";
+  setRo(els.roFire, "idle", false);
+  els.stopCam.disabled = true;
+  els.startCam.disabled = false;
+  setCamMsg("camera off - the editor works without it");
+}
+
+function onReading(reading) {
+  lastReading = reading;
+  const up = reading.present ? reading.up : null;
+  const res = control.update(up, performance.now());
+
+  hud.render({
+    present: reading.present,
+    up: reading.up,
+    extensions: reading.extensions,
+    progress: res.progress,
+    label: res.binding ? res.binding.label : "",
+  });
+
+  els.roPattern.textContent = reading.present
+    ? patternKey(reading.up)
+    : "-----";
+  els.roMatched.textContent = res.binding
+    ? res.binding.label || res.binding.action.type
+    : "none";
+
+  if (res.firing) {
+    // config tool: never navigate. Flash + name the action instead.
+    hud.flash();
+    const a = res.action;
+    const desc = a.type === "goto" ? `goto ${a.index}` : a.type;
+    setRo(els.roFire, `would fire: ${desc}`, true);
+    if (fireTimer) clearTimeout(fireTimer);
+    fireTimer = setTimeout(() => setRo(els.roFire, "idle", false), 1600);
+  }
+}
+
+function setRo(el, text, active) {
+  el.textContent = text;
+  el.classList.toggle("is-active", !!active);
+}
+
+function setCamMsg(text) {
+  els.camMsg.textContent = text;
+}
+
+// --- save / export / reset ----------------------------------------------
+function doSave() {
+  const ok = saveStored(validateConfig(working));
+  flashNote(
+    els.saveNote,
+    ok
+      ? "saved - reload the piece to apply"
+      : "could not save (storage unavailable)",
+  );
+}
+
+function doExport() {
+  const json = JSON.stringify(validateConfig(working), null, 2);
+  els.exportJson.value = json;
+  els.exportBox.hidden = false;
+  els.exportJson.focus();
+  els.exportJson.select();
+}
+
+async function doReset() {
+  clearStored();
+  const [defaults] = await Promise.all([fetchDefaults()]);
+  working = mergeConfig(defaults, null);
+  syncControl();
+  populate();
+  els.exportBox.hidden = true;
+  flashNote(els.saveNote, "reset to shipped defaults");
+}
+
+async function doCopy() {
+  const text = els.exportJson.value;
+  let ok = false;
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+      ok = true;
+    }
+  } catch {
+    ok = false;
+  }
+  if (!ok) {
+    // fallback: select + execCommand for older / insecure contexts
+    els.exportJson.focus();
+    els.exportJson.select();
+    try {
+      ok = document.execCommand("copy");
+    } catch {
+      ok = false;
+    }
+  }
+  els.copyJson.textContent = ok ? "Copied" : "Copy failed";
+  setTimeout(() => (els.copyJson.textContent = "Copy"), 1400);
+}
+
+function flashNote(el, text) {
+  el.textContent = text;
+  el.classList.remove("is-flash");
+  void el.offsetWidth;
+  el.classList.add("is-flash");
+}
+
+boot();

--- a/mother-not-metaphor/admin/index.html
+++ b/mother-not-metaphor/admin/index.html
@@ -1,0 +1,172 @@
+<!--
+       +
+       +
+   +++++++++
+       +        fragmentary - gesture console
+
+   a private dev tool. wire a hand shape to a page turn, set the dwell, watch
+   the finger bars, save it to this browser, export the JSON to bake into
+   data/gestures.json. not linked from the piece. keep these comments.
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <!-- resolve relative assets whether or not the URL has a trailing slash, so
+         /admin and /admin/ both resolve to ../ correctly. -->
+    <script>
+      (function () {
+        var p = location.pathname,
+          b;
+        if (p.charAt(p.length - 1) === "/") b = p;
+        else if (/\.[a-z0-9]+$/i.test(p)) b = p.replace(/[^/]*$/, "");
+        else b = p + "/";
+        document.write('<base href="' + b + '">');
+      })();
+    </script>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fragmentary - gesture console</title>
+    <link rel="stylesheet" href="../src/fragmentary/fragmentary.css" />
+    <link rel="stylesheet" href="admin.css" />
+  </head>
+  <body>
+    <header class="head">
+      <h1 class="head__title">Fragmentary</h1>
+      <p class="head__sub mono">
+        gesture console &middot; <span id="storage-key">…</span>
+      </p>
+    </header>
+
+    <main class="cols">
+      <!-- LIVE PANEL ----------------------------------------------------- -->
+      <section class="panel panel--live" aria-labelledby="live-h">
+        <h2 class="panel__h" id="live-h">Live</h2>
+
+        <div class="cam">
+          <video class="cam__video" id="cam-video" playsinline muted></video>
+          <p class="cam__msg mono" id="cam-msg" role="status">
+            camera off &middot; the editor works without it
+          </p>
+        </div>
+
+        <div class="controls-row">
+          <button class="btn" id="start-cam" type="button">Start camera</button>
+          <button class="btn" id="stop-cam" type="button" disabled>
+            Stop camera
+          </button>
+        </div>
+
+        <div class="hud-wrap" id="hud-wrap" aria-hidden="true"></div>
+
+        <dl class="readout mono">
+          <div class="readout__row">
+            <dt>pattern</dt>
+            <dd id="ro-pattern">-----</dd>
+          </div>
+          <div class="readout__row">
+            <dt>matched</dt>
+            <dd id="ro-matched">none</dd>
+          </div>
+          <div class="readout__row">
+            <dt>event</dt>
+            <dd id="ro-fire" class="readout__fire">idle</dd>
+          </div>
+        </dl>
+
+        <p class="note mono" id="live-note">
+          This is a config tool: poses do not turn the page here. When a pose
+          would fire, the meter flashes and the event line names the action.
+        </p>
+      </section>
+
+      <!-- EDITOR PANEL --------------------------------------------------- -->
+      <section class="panel panel--edit" aria-labelledby="edit-h">
+        <h2 class="panel__h" id="edit-h">Config</h2>
+
+        <div class="field">
+          <label class="field__label mono" for="dwell"
+            >Dwell hold
+            <span class="field__val" id="dwell-val">1.5s</span></label
+          >
+          <input
+            class="field__range"
+            id="dwell"
+            type="range"
+            min="300"
+            max="4000"
+            step="100"
+            value="1500"
+          />
+          <p class="field__hint mono">
+            How long a pose is held before it fires.
+          </p>
+        </div>
+
+        <div class="field field--inline">
+          <label class="field__label mono" for="stable-frames"
+            >Stable frames</label
+          >
+          <input
+            class="field__num"
+            id="stable-frames"
+            type="number"
+            min="1"
+            max="10"
+            step="1"
+            value="4"
+          />
+          <p class="field__hint mono">
+            Frames a pose must be steady before it counts (advanced).
+          </p>
+        </div>
+
+        <div class="bindings">
+          <div class="bindings__head">
+            <h3 class="bindings__h mono">Bindings</h3>
+            <div class="bindings__actions">
+              <button class="btn btn--sm" id="capture-pose" type="button">
+                Capture current pose
+              </button>
+              <button class="btn btn--sm" id="add-binding" type="button">
+                Add binding
+              </button>
+            </div>
+          </div>
+          <p class="bindings__legend mono" aria-hidden="true">
+            fingers: T I M R P &middot; cycle each - / up / down
+          </p>
+          <ul class="binding-list" id="binding-list"></ul>
+        </div>
+
+        <div class="controls-row controls-row--save">
+          <button class="btn btn--primary" id="save" type="button">Save</button>
+          <button class="btn" id="export" type="button">Export JSON</button>
+          <button class="btn" id="reset" type="button">
+            Reset to defaults
+          </button>
+        </div>
+        <p class="note mono" id="save-note" role="status"></p>
+
+        <div class="export" id="export-box" hidden>
+          <div class="export__head">
+            <label class="field__label mono" for="export-json"
+              >data/gestures.json</label
+            >
+            <button class="btn btn--sm" id="copy-json" type="button">
+              Copy
+            </button>
+          </div>
+          <textarea
+            class="export__text mono"
+            id="export-json"
+            readonly
+            rows="16"
+            spellcheck="false"
+          ></textarea>
+        </div>
+      </section>
+    </main>
+
+    <script type="module" src="admin.js"></script>
+  </body>
+</html>

--- a/mother-not-metaphor/data/gestures.json
+++ b/mother-not-metaphor/data/gestures.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "Fragmentary gesture config for mother-not-metaphor. Editable live at /admin/. dwellMs = how long a pose is held before it fires (~1.5s). Each binding maps a finger pattern (thumb,index,middle,ring,pinky : any|up|down) to an action. A relaxed hand matches nothing (a neutral), so switches only happen on a deliberately-formed shape - relax between gestures.",
+  "dwellMs": 1500,
+  "stableFrames": 4,
+  "showHud": true,
+  "bindings": [
+    {
+      "id": "next",
+      "label": "open hand → next",
+      "action": { "type": "next" },
+      "fingers": {
+        "thumb": "up",
+        "index": "up",
+        "middle": "up",
+        "ring": "up",
+        "pinky": "up"
+      }
+    },
+    {
+      "id": "back",
+      "label": "peace sign → back",
+      "action": { "type": "prev" },
+      "fingers": {
+        "thumb": "down",
+        "index": "up",
+        "middle": "up",
+        "ring": "down",
+        "pinky": "down"
+      }
+    }
+  ]
+}

--- a/mother-not-metaphor/data/poem.json
+++ b/mother-not-metaphor/data/poem.json
@@ -1,0 +1,186 @@
+{
+  "title": "mother, not metaphor",
+  "credit": "Halim Madi",
+  "palette": {
+    "paper": "#f3f3f1",
+    "ink": "#141414",
+    "blue": "#2138de",
+    "sky": "#3e8ede",
+    "red": "#e8381f",
+    "amber": "#e9a21c",
+    "green": "#1e854a"
+  },
+  "pacing": {
+    "msPerChar": 55,
+    "minMomentMs": 4200,
+    "maxMomentMs": 13000,
+    "morphMs": 560
+  },
+  "moments": [
+    {
+      "id": "en",
+      "lang": "EN",
+      "dir": "ltr",
+      "layout": "L1",
+      "original": "Mother, there's an ocean, a sea, and a war between your ribs and my palms.",
+      "english": null,
+      "note": "ocean, sea, war stack between the ribs",
+      "illustration": {
+        "viewBox": "0 0 100 100",
+        "keyframes": [
+          [
+            { "x": 14, "y": 12, "w": 72, "h": 46, "fill": "blue", "o": 1 },
+            { "x": 14, "y": 69, "w": 72, "h": 0, "fill": "sky", "o": 0 },
+            { "x": 14, "y": 85, "w": 72, "h": 0, "fill": "red", "o": 0 }
+          ],
+          [
+            { "x": 14, "y": 12, "w": 72, "h": 46, "fill": "blue", "o": 1 },
+            { "x": 14, "y": 64, "w": 72, "h": 10, "fill": "sky", "o": 1 },
+            { "x": 14, "y": 85, "w": 72, "h": 0, "fill": "red", "o": 0 }
+          ],
+          [
+            { "x": 14, "y": 12, "w": 72, "h": 46, "fill": "blue", "o": 1 },
+            { "x": 14, "y": 64, "w": 72, "h": 10, "fill": "sky", "o": 1 },
+            { "x": 14, "y": 80, "w": 72, "h": 10, "fill": "red", "o": 1 }
+          ]
+        ]
+      }
+    },
+    {
+      "id": "fr",
+      "lang": "FR",
+      "dir": "ltr",
+      "layout": "L2",
+      "original": "Ma mère l'absence de tes côtes est la seule présence que je ressens et mes mains ne pressent pas mais pétrissent plutôt l'air en un pain immangeable",
+      "english": "My mother, the absence of your ribs is the only presence I feel, and my hands do not press but rather knead the air into an inedible bread.",
+      "note": "ribs (slats) -> two hands -> dough -> burnt loaf",
+      "illustration": {
+        "viewBox": "0 0 100 100",
+        "keyframes": [
+          [
+            { "x": 18, "y": 12, "w": 64, "h": 6, "fill": "red", "o": 1 },
+            { "x": 18, "y": 23, "w": 64, "h": 6, "fill": "red", "o": 1 },
+            { "x": 18, "y": 34, "w": 64, "h": 6, "fill": "red", "o": 1 },
+            { "x": 18, "y": 45, "w": 64, "h": 6, "fill": "red", "o": 1 },
+            { "x": 18, "y": 56, "w": 64, "h": 6, "fill": "red", "o": 1 },
+            { "x": 18, "y": 67, "w": 64, "h": 6, "fill": "red", "o": 1 },
+            { "x": 18, "y": 78, "w": 64, "h": 6, "fill": "red", "o": 1 }
+          ],
+          [
+            { "x": 20, "y": 18, "w": 26, "h": 8, "fill": "red", "o": 1 },
+            { "x": 20, "y": 34, "w": 26, "h": 8, "fill": "red", "o": 1 },
+            { "x": 20, "y": 50, "w": 26, "h": 8, "fill": "red", "o": 1 },
+            { "x": 20, "y": 66, "w": 26, "h": 8, "fill": "red", "o": 1 },
+            { "x": 54, "y": 26, "w": 26, "h": 8, "fill": "red", "o": 1 },
+            { "x": 54, "y": 44, "w": 26, "h": 8, "fill": "red", "o": 1 },
+            { "x": 54, "y": 62, "w": 26, "h": 8, "fill": "red", "o": 1 }
+          ],
+          [
+            { "x": 22, "y": 26, "w": 56, "h": 48, "fill": "amber", "o": 1 },
+            { "x": 22, "y": 26, "w": 56, "h": 48, "fill": "amber", "o": 1 },
+            { "x": 22, "y": 26, "w": 56, "h": 48, "fill": "amber", "o": 1 },
+            { "x": 22, "y": 26, "w": 56, "h": 48, "fill": "amber", "o": 1 },
+            { "x": 22, "y": 26, "w": 56, "h": 48, "fill": "amber", "o": 1 },
+            { "x": 22, "y": 26, "w": 56, "h": 48, "fill": "amber", "o": 1 },
+            { "x": 22, "y": 26, "w": 56, "h": 48, "fill": "amber", "o": 1 }
+          ],
+          [
+            { "x": 26, "y": 26, "w": 48, "h": 48, "fill": "ink", "o": 1 },
+            { "x": 26, "y": 26, "w": 48, "h": 48, "fill": "ink", "o": 1 },
+            { "x": 26, "y": 26, "w": 48, "h": 48, "fill": "ink", "o": 1 },
+            { "x": 26, "y": 26, "w": 48, "h": 48, "fill": "ink", "o": 1 },
+            { "x": 26, "y": 26, "w": 48, "h": 48, "fill": "ink", "o": 1 },
+            { "x": 26, "y": 26, "w": 48, "h": 48, "fill": "ink", "o": 1 },
+            { "x": 26, "y": 26, "w": 48, "h": 48, "fill": "ink", "o": 1 }
+          ]
+        ]
+      }
+    },
+    {
+      "id": "ar",
+      "lang": "AR",
+      "dir": "ltr",
+      "layout": "L3",
+      "original": "Oummi dam3i salibon yachtoubou fi wajhi sabila khalasen mousta7il",
+      "english": "Mother, my tears are a cross written on my face - an impossible path to salvation.",
+      "note": "one cross, color cycling black -> blue -> amber -> red",
+      "illustration": {
+        "viewBox": "0 0 100 100",
+        "keyframes": [
+          [
+            { "x": 43, "y": 14, "w": 14, "h": 72, "fill": "ink", "o": 1 },
+            { "x": 28, "y": 40, "w": 44, "h": 14, "fill": "ink", "o": 1 }
+          ],
+          [
+            { "x": 43, "y": 14, "w": 14, "h": 72, "fill": "blue", "o": 1 },
+            { "x": 28, "y": 40, "w": 44, "h": 14, "fill": "blue", "o": 1 }
+          ],
+          [
+            { "x": 43, "y": 14, "w": 14, "h": 72, "fill": "amber", "o": 1 },
+            { "x": 28, "y": 40, "w": 44, "h": 14, "fill": "amber", "o": 1 }
+          ],
+          [
+            { "x": 43, "y": 14, "w": 14, "h": 72, "fill": "red", "o": 1 },
+            { "x": 28, "y": 40, "w": 44, "h": 14, "fill": "red", "o": 1 }
+          ]
+        ]
+      }
+    },
+    {
+      "id": "ar-lev",
+      "lang": "AR-Levantine",
+      "dir": "ltr",
+      "layout": "L4",
+      "original": "Mama wa3adtik 2erja3 2e23oud ma3ik. Cigara w kess whiskey.",
+      "english": "Mama, I promised I'd come back and sit with you. A cigarette and a glass of whiskey.",
+      "note": "cigarette (amber bar + ember) -> a glass of whiskey",
+      "illustration": {
+        "viewBox": "0 0 100 100",
+        "keyframes": [
+          [
+            { "x": 20, "y": 42, "w": 34, "h": 7, "fill": "amber", "o": 1 },
+            { "x": 58, "y": 41, "w": 9, "h": 9, "fill": "ink", "o": 1 }
+          ],
+          [
+            { "x": 54, "y": 60, "w": 28, "h": 12, "fill": "amber", "o": 1 },
+            { "x": 54, "y": 42, "w": 28, "h": 18, "fill": "blue", "o": 1 }
+          ]
+        ]
+      }
+    },
+    {
+      "id": "pt-br",
+      "lang": "PT-BR",
+      "dir": "ltr",
+      "layout": "L5",
+      "original": "mas mama preciso de outra língua pra esconder o quanto são impróprias a minha distância e a minha incompletude quando você não está por perto",
+      "english": "but mama I need another language to hide the inappropriateness of both my distance and my incompleteness when you're not around.",
+      "note": "every color recombined into one mosaic - the other language",
+      "illustration": {
+        "viewBox": "0 0 100 100",
+        "keyframes": [
+          [
+            { "x": 19, "y": 22, "w": 6, "h": 6, "fill": "green", "o": 0.12 },
+            { "x": 36, "y": 22, "w": 6, "h": 6, "fill": "ink", "o": 0.12 },
+            { "x": 48, "y": 22, "w": 6, "h": 6, "fill": "red", "o": 0.12 },
+            { "x": 70, "y": 22, "w": 6, "h": 6, "fill": "amber", "o": 0.12 },
+            { "x": 47, "y": 46, "w": 6, "h": 6, "fill": "blue", "o": 0.12 },
+            { "x": 18, "y": 71, "w": 6, "h": 6, "fill": "green", "o": 0.12 },
+            { "x": 46, "y": 71, "w": 6, "h": 6, "fill": "amber", "o": 0.12 },
+            { "x": 75, "y": 71, "w": 6, "h": 6, "fill": "red", "o": 0.12 }
+          ],
+          [
+            { "x": 12, "y": 14, "w": 20, "h": 22, "fill": "green", "o": 1 },
+            { "x": 34, "y": 14, "w": 10, "h": 22, "fill": "ink", "o": 1 },
+            { "x": 46, "y": 14, "w": 10, "h": 22, "fill": "red", "o": 1 },
+            { "x": 58, "y": 14, "w": 30, "h": 22, "fill": "amber", "o": 1 },
+            { "x": 12, "y": 40, "w": 76, "h": 18, "fill": "blue", "o": 1 },
+            { "x": 12, "y": 62, "w": 18, "h": 24, "fill": "green", "o": 1 },
+            { "x": 32, "y": 62, "w": 34, "h": 24, "fill": "amber", "o": 1 },
+            { "x": 68, "y": 62, "w": 20, "h": 24, "fill": "red", "o": 1 }
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/mother-not-metaphor/index.html
+++ b/mother-not-metaphor/index.html
@@ -1,0 +1,98 @@
+<!--
+       +
+       +
+   +++++++++
+       +        mother, not metaphor
+
+   five tongues for one mother. the camera is the performer; the hands turn the
+   page; the little colored blocks are the only language left. a reusable poem
+   machine - components inside a phone-sized frame. keep these comments.
+-->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <!-- resolve relative assets whether or not the URL has a trailing slash, so
+         /mother-not-metaphor and /mother-not-metaphor/ both work. -->
+    <script>
+      (function () {
+        var p = location.pathname,
+          b;
+        if (p.charAt(p.length - 1) === "/") b = p;
+        else if (/\.[a-z0-9]+$/i.test(p)) b = p.replace(/[^/]*$/, "");
+        else b = p + "/";
+        document.write('<base href="' + b + '">');
+      })();
+    </script>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
+    <title>mother, not metaphor</title>
+    <meta
+      name="description"
+      content="A poem in five tongues for one mother - a live performance instrument of camera, words and morphing color, sized for a phone."
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <h1 class="sr-only">mother, not metaphor - a poem in five tongues</h1>
+
+    <main
+      class="stage"
+      id="stage"
+      data-layout="L1"
+      aria-label="mother, not metaphor"
+    >
+      <!-- ME: the performer's camera (or, with no camera, the name) -->
+      <section class="box box--me" id="box-me" aria-label="performer">
+        <video class="cam-video" id="cam-video" playsinline muted></video>
+        <div class="cam-fallback" id="cam-fallback">
+          <span class="cam-fallback__name">Halim Madi</span>
+          <span class="cam-fallback__sub mono">mother, not metaphor</span>
+        </div>
+        <span class="box-label mono" aria-hidden="true">me</span>
+      </section>
+
+      <!-- WORDS: the line, revealed as if transcribed live, with translation -->
+      <section class="box box--words" id="box-words" aria-label="words">
+        <div class="words-tag mono" id="words-tag" aria-hidden="true"></div>
+        <p class="words-caption" id="words-caption" aria-live="polite"></p>
+        <p class="words-translation" id="words-translation"></p>
+        <span class="caret" aria-hidden="true"></span>
+        <span class="box-label mono" aria-hidden="true">words</span>
+      </section>
+
+      <!-- ILLUSTRATION: flat-geometric color that morphs, paced to speech -->
+      <section class="box box--illus" id="box-illus" aria-label="illustration">
+        <svg
+          class="illus-svg"
+          id="illus-svg"
+          viewBox="0 0 100 100"
+          preserveAspectRatio="xMidYMid meet"
+          aria-hidden="true"
+        ></svg>
+        <span class="box-label mono" aria-hidden="true">illustration</span>
+      </section>
+
+      <div class="hint mono" id="hint" aria-hidden="true"></div>
+
+      <!-- the start gate: a tap so the browser will grant the camera -->
+      <div class="intro" id="intro" hidden>
+        <div class="intro__inner">
+          <h2 class="intro__title">mother, not metaphor</h2>
+          <p class="intro__note" id="intro-note">
+            A poem in five tongues. Let the camera see your hands - change their
+            shape to turn from one tongue to the next. No camera? It plays
+            itself.
+          </p>
+          <button class="intro__start" id="start" type="button">begin</button>
+        </div>
+      </div>
+    </main>
+
+    <a class="back mono" href="/">oulipo.xyz</a>
+
+    <script type="module" src="src/main.js"></script>
+  </body>
+</html>

--- a/mother-not-metaphor/index.html
+++ b/mother-not-metaphor/index.html
@@ -33,6 +33,7 @@
       name="description"
       content="A poem in five tongues for one mother - a live performance instrument of camera, words and morphing color, sized for a phone."
     />
+    <link rel="stylesheet" href="src/fragmentary/fragmentary.css" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
@@ -75,6 +76,9 @@
         <span class="box-label mono" aria-hidden="true">illustration</span>
       </section>
 
+      <!-- Fragmentary HUD: 5 finger bars + the dwell meter (built by hud.js) -->
+      <div class="hud-panel" id="hud-panel" aria-hidden="true"></div>
+
       <div class="hint mono" id="hint" aria-hidden="true"></div>
 
       <!-- the start gate: a tap so the browser will grant the camera -->
@@ -82,8 +86,9 @@
         <div class="intro__inner">
           <h2 class="intro__title">mother, not metaphor</h2>
           <p class="intro__note" id="intro-note">
-            A poem in five tongues. Let the camera see your hands - change their
-            shape to turn from one tongue to the next. No camera? It plays
+            A poem in five tongues. Let the camera see your hand: hold an open
+            hand to move forward, a peace sign to go back. Hold the shape a
+            moment - relax your hand between gestures. No camera? It plays
             itself.
           </p>
           <button class="intro__start" id="start" type="button">begin</button>

--- a/mother-not-metaphor/package-lock.json
+++ b/mother-not-metaphor/package-lock.json
@@ -1,0 +1,266 @@
+{
+  "name": "mother-not-metaphor-dev",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mother-not-metaphor-dev",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@playwright/test": "latest",
+        "html-validate": "latest"
+      }
+    },
+    "node_modules/@html-validate/stylish": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@html-validate/stylish/-/stylish-6.0.0.tgz",
+      "integrity": "sha512-d1/lI3qIXhGVJF3+MmKEBn1dRX6U4Z+BDaOdDI3E6SXcO+OQ7hC/3mSo6BIjwQlcuV6NdDOKm6QCrzIQL1EezQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.16.0 || >= 24.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sidvind/better-ajv-errors": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-7.0.0.tgz",
+      "integrity": "sha512-imVsp5D3KxJ8+uUmu2dsLKnFg3qdX952v/L1gZoCa0NO2ivhQWHMpYM2KmpFrRXHWFjlqkNZ/935nxiTqXEi1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^22.12 || >= 24.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/html-validate": {
+      "version": "11.5.3",
+      "resolved": "https://registry.npmjs.org/html-validate/-/html-validate-11.5.3.tgz",
+      "integrity": "sha512-YJAqUomHuND2ppz4QoRoWMm4tLHFxGTkqoBDiMjBm9pzictNkEB78q0yT3U9s6oiy9XoEmVC2QEQcube+fMw5g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/html-validate"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@html-validate/stylish": "^6.0.0",
+        "@sidvind/better-ajv-errors": "7.0.0",
+        "ajv": "^8.0.0",
+        "kleur": "^4.1.0",
+        "prompts": "^2.0.0",
+        "semver": "^7.0.0"
+      },
+      "bin": {
+        "html-validate": "bin/html-validate.mjs"
+      },
+      "engines": {
+        "node": "^22.22.0 || >= 24.8.0"
+      },
+      "peerDependencies": {
+        "@jest/globals": "^29.0.3 || ^30.0.0",
+        "@vitest/expect": "^3.0.0 || ^4.0.1",
+        "jest": "^29.0.3 || ^30.0.0",
+        "jest-snapshot": "^29.0.3 || ^30.0.0",
+        "vitest": "^3.0.0 || ^4.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@jest/globals": {
+          "optional": true
+        },
+        "@vitest/expect": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "jest-snapshot": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prompts/node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/mother-not-metaphor/package.json
+++ b/mother-not-metaphor/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mother-not-metaphor-dev",
+  "version": "0.0.1",
+  "description": "DEV-ONLY harness for the mother-not-metaphor net.art poem engine. Never ships.",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "serve": "node scripts/serve.mjs",
+    "test:unit": "node --test --test-concurrency=1 tests/unit/*.test.mjs",
+    "test:e2e": "playwright test",
+    "lint:html": "html-validate index.html",
+    "verify:purity": "node scripts/verify-purity.mjs",
+    "test": "npm run test:unit && npm run lint:html && npm run verify:purity && npm run test:e2e"
+  },
+  "devDependencies": {
+    "@playwright/test": "latest",
+    "html-validate": "latest"
+  }
+}

--- a/mother-not-metaphor/package.json
+++ b/mother-not-metaphor/package.json
@@ -8,7 +8,7 @@
     "serve": "node scripts/serve.mjs",
     "test:unit": "node --test --test-concurrency=1 tests/unit/*.test.mjs",
     "test:e2e": "playwright test",
-    "lint:html": "html-validate index.html",
+    "lint:html": "html-validate index.html admin/index.html",
     "verify:purity": "node scripts/verify-purity.mjs",
     "test": "npm run test:unit && npm run lint:html && npm run verify:purity && npm run test:e2e"
   },

--- a/mother-not-metaphor/playwright.config.mjs
+++ b/mother-not-metaphor/playwright.config.mjs
@@ -1,0 +1,63 @@
+/**
+ * playwright.config.mjs - mother-not-metaphor DEV-ONLY Playwright configuration
+ *
+ * Chromium-only. Three projects:
+ *   mobile          - iPhone 13 (coarse pointer, touch)
+ *   desktop         - Desktop Chrome
+ *   reduced-motion  - Desktop Chrome + reducedMotion:reduce
+ *
+ * webServer starts the local static server on port 4180. The e2e suite exercises
+ * the no-camera auto-play fallback (headless Chromium has no camera), which is the
+ * deterministic path - hand tracking is a live-only enhancement.
+ */
+
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+
+  reporter: "list",
+
+  use: {
+    baseURL: "http://localhost:4180",
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+
+  projects: [
+    {
+      name: "mobile",
+      use: {
+        ...devices["iPhone 13"],
+        defaultBrowserType: "chromium",
+        hasTouch: true,
+        isMobile: true,
+      },
+    },
+    {
+      name: "desktop",
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+    {
+      name: "reduced-motion",
+      use: {
+        ...devices["Desktop Chrome"],
+        reducedMotion: "reduce",
+      },
+    },
+  ],
+
+  webServer: {
+    command: "npm run serve",
+    port: 4180,
+    reuseExistingServer: true,
+    timeout: 10_000,
+  },
+});

--- a/mother-not-metaphor/scripts/serve.mjs
+++ b/mother-not-metaphor/scripts/serve.mjs
@@ -1,0 +1,87 @@
+/**
+ * scripts/serve.mjs - mother-not-metaphor DEV-ONLY static file server
+ *
+ * Zero-dependency Node static server using node:http, node:fs, node:path.
+ * Serves the mother-not-metaphor root directory. Returns 404 for missing files.
+ * Not a SPA - no fallback to index.html.
+ */
+
+import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 4180;
+
+const MIME_TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".mjs": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".otf": "font/otf",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".txt": "text/plain; charset=utf-8",
+};
+
+function mimeFor(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  return MIME_TYPES[ext] || "application/octet-stream";
+}
+
+const server = http.createServer((req, res) => {
+  let urlPath;
+  try {
+    urlPath = decodeURIComponent(new URL(req.url, "http://localhost").pathname);
+  } catch {
+    res.writeHead(400);
+    res.end("Bad Request");
+    return;
+  }
+
+  let filePath = path.resolve(ROOT, "." + urlPath);
+  if (!filePath.startsWith(ROOT)) {
+    res.writeHead(403);
+    res.end("Forbidden");
+    return;
+  }
+
+  if (fs.existsSync(filePath) && fs.statSync(filePath).isDirectory()) {
+    filePath = path.join(filePath, "index.html");
+  }
+
+  if (!fs.existsSync(filePath)) {
+    res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end(`404 Not Found: ${urlPath}`);
+    return;
+  }
+
+  const stat = fs.statSync(filePath);
+  if (!stat.isFile()) {
+    res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end(`404 Not Found: ${urlPath}`);
+    return;
+  }
+
+  res.writeHead(200, {
+    "Content-Type": mimeFor(filePath),
+    "Content-Length": stat.size,
+    "Cache-Control": "no-cache, no-store, must-revalidate",
+  });
+
+  fs.createReadStream(filePath).pipe(res);
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.log(
+    `mother-not-metaphor dev server running at http://localhost:${PORT}`,
+  );
+});

--- a/mother-not-metaphor/scripts/verify-purity.mjs
+++ b/mother-not-metaphor/scripts/verify-purity.mjs
@@ -1,0 +1,157 @@
+/**
+ * scripts/verify-purity.mjs - mother-not-metaphor DEV-ONLY purity checker
+ *
+ * This piece needs live hand tracking, so unlike the strictly-offline pieces
+ * (mother-patina, votive-patina) it loads ONE external dependency: the MediaPipe
+ * Hand Landmarker bundle + model. Everything else stays clean. This guards that
+ * boundary:
+ *   1. index.html opens with an HTML comment containing the relic marker '+'.
+ *   2. Shipped JS (src/**.js) has NO analytics/trackers (gtag, beacons, GA, ...).
+ *   3. The ONLY remote references allowed are the MediaPipe CDN + model host.
+ *      Any other remote fetch/import/from is a failure.
+ *   4. No shipped .js looks minified.
+ *
+ * Exit 0 on all PASS, exit 1 otherwise.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const G = "\x1b[32m",
+  R = "\x1b[31m",
+  B = "\x1b[1m",
+  D = "\x1b[2m",
+  X = "\x1b[0m";
+const pass = (l) => console.log(`  ${G}PASS${X} ${l}`);
+const fail = (l, d) => {
+  console.log(`  ${R}FAIL${X} ${l}`);
+  if (d) console.log(`       ${D}${d}${X}`);
+};
+
+// Surveillance / analytics patterns are NEVER allowed anywhere.
+const TRACKER_PATTERNS = [
+  "XMLHttpRequest",
+  "navigator.sendBeacon",
+  "gtag(",
+  "googletagmanager",
+  "google-analytics",
+  "new WebSocket(",
+  "EventSource(",
+  "fbq(",
+  "mixpanel",
+  "segment.com",
+];
+
+// Hosts the piece is allowed to reach (the hand-tracking model + its runtime).
+const ALLOWED_HOSTS = [
+  "cdn.jsdelivr.net/npm/@mediapipe/tasks-vision",
+  "storage.googleapis.com/mediapipe-models/hand_landmarker",
+];
+
+// any remote reference: fetch(...)/import(...)/from "..." pointing at http(s):// or //host
+const REMOTE_REF_RE =
+  /(?:\b(?:fetch|import)\s*\(\s*|\bfrom\s+)[`'"]\s*((?:https?:)?\/\/[^`'"\s)]+)/gi;
+
+function shippedJs() {
+  const files = [];
+  const walk = (dir) => {
+    if (!fs.existsSync(dir)) return;
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fp = path.join(dir, e.name);
+      if (e.isDirectory()) walk(fp);
+      else if (e.name.endsWith(".js")) files.push(fp);
+    }
+  };
+  walk(path.join(ROOT, "src"));
+  return files;
+}
+
+function checkRelic() {
+  const p = path.join(ROOT, "index.html");
+  if (!fs.existsSync(p))
+    return (fail("relic-comment", "index.html missing"), false);
+  const t = fs.readFileSync(p, "utf8").trimStart();
+  if (!t.startsWith("<!--"))
+    return (fail("relic-comment", "no leading comment"), false);
+  const end = t.indexOf("-->");
+  if (end === -1 || !t.slice(0, end).includes("+"))
+    return (fail("relic-comment", "first comment lacks '+'"), false);
+  return (
+    pass("relic-comment: index.html opens with <!-- ... + ... -->"),
+    true
+  );
+}
+
+function checkNoTrackers() {
+  const files = shippedJs();
+  if (!files.length) return (pass("no-trackers: no shipped JS yet"), true);
+  let ok = true;
+  for (const fp of files) {
+    const rel = path.relative(ROOT, fp);
+    const src = fs.readFileSync(fp, "utf8");
+    const hits = TRACKER_PATTERNS.filter((p) => src.includes(p));
+    if (hits.length)
+      (fail(`no-trackers [${rel}]`, hits.join(", ")), (ok = false));
+    else pass(`no-trackers [${rel}]`);
+  }
+  return ok;
+}
+
+function checkRemoteAllowlist() {
+  const files = shippedJs();
+  if (!files.length) return (pass("remote-allowlist: no shipped JS yet"), true);
+  let ok = true;
+  for (const fp of files) {
+    const rel = path.relative(ROOT, fp);
+    const src = fs.readFileSync(fp, "utf8");
+    const bad = [];
+    for (const m of src.matchAll(REMOTE_REF_RE)) {
+      const url = m[1].replace(/^https?:/, "").replace(/^\/\//, "");
+      if (!ALLOWED_HOSTS.some((h) => url.startsWith(h))) bad.push(m[1]);
+    }
+    if (bad.length)
+      (fail(`remote-allowlist [${rel}]`, bad.join(", ")), (ok = false));
+    else pass(`remote-allowlist [${rel}]`);
+  }
+  return ok;
+}
+
+function checkNotMinified() {
+  const files = shippedJs();
+  if (!files.length) return (pass("not-minified: no shipped JS yet"), true);
+  let ok = true;
+  for (const fp of files) {
+    const rel = path.relative(ROOT, fp);
+    const src = fs.readFileSync(fp, "utf8");
+    const bytes = Buffer.byteLength(src, "utf8");
+    const nl = (src.match(/\n/g) || []).length;
+    const maxLine = Math.max(...src.split("\n").map((l) => l.length));
+    if ((bytes > 2048 && nl < 3) || maxLine > 2000)
+      (fail(
+        `not-minified [${rel}]`,
+        `looks minified (${bytes}B, maxline ${maxLine})`,
+      ),
+        (ok = false));
+    else pass(`not-minified [${rel}]`);
+  }
+  return ok;
+}
+
+console.log(`\n${B}mother-not-metaphor purity check${X}`);
+console.log(`${D}root: ${ROOT}${X}\n`);
+const results = [
+  checkRelic(),
+  checkNoTrackers(),
+  checkRemoteAllowlist(),
+  checkNotMinified(),
+];
+console.log("");
+if (results.every(Boolean)) {
+  console.log(`${G}${B}ALL ${results.length} CHECKS PASSED${X}`);
+  process.exit(0);
+}
+console.log(`${R}${B}${results.filter((r) => !r).length} CHECK(S) FAILED${X}`);
+process.exit(1);

--- a/mother-not-metaphor/scripts/verify-purity.mjs
+++ b/mother-not-metaphor/scripts/verify-purity.mjs
@@ -66,6 +66,7 @@ function shippedJs() {
     }
   };
   walk(path.join(ROOT, "src"));
+  walk(path.join(ROOT, "admin"));
   return files;
 }
 

--- a/mother-not-metaphor/src/camera.js
+++ b/mother-not-metaphor/src/camera.js
@@ -1,0 +1,34 @@
+/**
+ * src/camera.js - the performer's live video (DOM).
+ *
+ * Wraps getUserMedia. No audio, front camera. The stream is shown mirrored and
+ * is never recorded or sent anywhere - it exists only to be looked at and, when
+ * hand tracking is available, to read the performer's hand shape locally.
+ */
+
+export async function startCamera(videoEl) {
+  if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+    throw new Error("getUserMedia unavailable");
+  }
+  const stream = await navigator.mediaDevices.getUserMedia({
+    video: {
+      facingMode: "user",
+      width: { ideal: 640 },
+      height: { ideal: 640 },
+    },
+    audio: false,
+  });
+  videoEl.srcObject = stream;
+  videoEl.muted = true;
+  videoEl.setAttribute("playsinline", "");
+  await videoEl.play();
+  return stream;
+}
+
+export function stopCamera(videoEl) {
+  const s = videoEl && videoEl.srcObject;
+  if (s) {
+    for (const t of s.getTracks()) t.stop();
+    videoEl.srcObject = null;
+  }
+}

--- a/mother-not-metaphor/src/color.js
+++ b/mother-not-metaphor/src/color.js
@@ -1,0 +1,88 @@
+/**
+ * src/color.js - perceptual color interpolation (pure, DOM-free).
+ *
+ * The illustrations morph between saturated primaries (blue, red, amber, green,
+ * black). Interpolating those in sRGB produces muddy grey mid-tones. We convert
+ * to OKLab (Bjorn Ottosson's perceptual space), lerp there, and convert back, so
+ * blue -> red passes through vivid purples/magentas instead of grey.
+ */
+
+const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
+const lerp = (a, b, t) => a + (b - a) * t;
+
+export function hexToRgb(hex) {
+  let h = hex.trim().replace(/^#/, "");
+  if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+  const n = parseInt(h, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+export function rgbToHex(r, g, b) {
+  const to = (v) =>
+    Math.round(clamp01(v / 255) * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return "#" + to(r) + to(g) + to(b);
+}
+
+// sRGB channel (0-255) <-> linear (0-1)
+const toLinear = (c) => {
+  c /= 255;
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+};
+const toSrgb = (c) => {
+  const v = c <= 0.0031308 ? 12.92 * c : 1.055 * Math.pow(c, 1 / 2.4) - 0.055;
+  return clamp01(v) * 255;
+};
+
+export function rgbToOklab(r, g, b) {
+  const lr = toLinear(r),
+    lg = toLinear(g),
+    lb = toLinear(b);
+  const l = 0.4122214708 * lr + 0.5363325363 * lg + 0.0514459929 * lb;
+  const m = 0.2119034982 * lr + 0.6806995451 * lg + 0.1073969566 * lb;
+  const s = 0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb;
+  const l_ = Math.cbrt(l),
+    m_ = Math.cbrt(m),
+    s_ = Math.cbrt(s);
+  return [
+    0.2104542553 * l_ + 0.793617785 * m_ - 0.0040720468 * s_,
+    1.9779984951 * l_ - 2.428592205 * m_ + 0.4505937099 * s_,
+    0.0259040371 * l_ + 0.7827717662 * m_ - 0.808675766 * s_,
+  ];
+}
+
+export function oklabToRgb(L, a, b) {
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+  const l = l_ * l_ * l_,
+    m = m_ * m_ * m_,
+    s = s_ * s_ * s_;
+  const lr = 4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s;
+  const lg = -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s;
+  const lb = -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s;
+  return [toSrgb(lr), toSrgb(lg), toSrgb(lb)];
+}
+
+/** Interpolate two hex colors through OKLab. Returns a #rrggbb string. */
+export function lerpColor(hexA, hexB, t) {
+  if (t <= 0) return normalizeHex(hexA);
+  if (t >= 1) return normalizeHex(hexB);
+  const [r1, g1, b1] = hexToRgb(hexA);
+  const [r2, g2, b2] = hexToRgb(hexB);
+  const [L1, a1, bb1] = rgbToOklab(r1, g1, b1);
+  const [L2, a2, bb2] = rgbToOklab(r2, g2, b2);
+  const [r, g, b] = oklabToRgb(
+    lerp(L1, L2, t),
+    lerp(a1, a2, t),
+    lerp(bb1, bb2, t),
+  );
+  return rgbToHex(r, g, b);
+}
+
+/** Canonicalize a hex string to lowercase 6-digit #rrggbb. */
+export function normalizeHex(hex) {
+  const [r, g, b] = hexToRgb(hex);
+  return rgbToHex(r, g, b);
+}

--- a/mother-not-metaphor/src/fragmentary/config.js
+++ b/mother-not-metaphor/src/fragmentary/config.js
@@ -1,0 +1,116 @@
+/**
+ * fragmentary/config.js - gesture config: validate, merge, persist (pure-ish).
+ *
+ * The config is a small JSON object:
+ *   { dwellMs, stableFrames, showHud, bindings:[ { id, label, action, fingers } ] }
+ * A shipped default lives in data/gestures.json; the admin portal writes an
+ * override to localStorage (per origin), which the live piece layers on top. All
+ * the logic here is pure and Node-testable; the localStorage helpers no-op when
+ * there is no storage (e.g. under `node --test`).
+ */
+
+export const STORAGE_KEY = "fragmentary:mother-not-metaphor";
+export const FINGERS = ["thumb", "index", "middle", "ring", "pinky"];
+export const ACTIONS = ["next", "prev", "goto", "restart"];
+const CONSTRAINTS = ["any", "up", "down"];
+
+const clampNum = (v, lo, hi, dflt) => {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return dflt;
+  return Math.min(hi, Math.max(lo, n));
+};
+
+export function normalizeAction(a) {
+  const type = a && ACTIONS.includes(a.type) ? a.type : "next";
+  const out = { type };
+  if (type === "goto")
+    out.index = Math.max(0, Math.floor(Number(a && a.index) || 0));
+  return out;
+}
+
+export function normalizeFingers(f) {
+  const out = {};
+  for (const name of FINGERS) {
+    const c = f && f[name];
+    out[name] = CONSTRAINTS.includes(c) ? c : "any";
+  }
+  return out;
+}
+
+export function normalizeBinding(b, i = 0) {
+  if (!b || typeof b !== "object") return null;
+  return {
+    id: typeof b.id === "string" && b.id ? b.id : `b${i}`,
+    label: typeof b.label === "string" ? b.label : "",
+    action: normalizeAction(b.action),
+    fingers: normalizeFingers(b.fingers),
+  };
+}
+
+/** Coerce any input into a valid, complete config. Never throws. */
+export function validateConfig(cfg) {
+  const c = cfg && typeof cfg === "object" ? cfg : {};
+  const bindings = Array.isArray(c.bindings) ? c.bindings : [];
+  return {
+    dwellMs: clampNum(c.dwellMs, 300, 6000, 1500),
+    stableFrames: Math.round(clampNum(c.stableFrames, 1, 15, 4)),
+    showHud: c.showHud !== false,
+    bindings: bindings.map((b, i) => normalizeBinding(b, i)).filter(Boolean),
+  };
+}
+
+/** Layer a (partial) override on top of defaults, then validate. */
+export function mergeConfig(defaults, override) {
+  const d = validateConfig(defaults);
+  if (!override || typeof override !== "object") return d;
+  return validateConfig({
+    dwellMs: override.dwellMs != null ? override.dwellMs : d.dwellMs,
+    stableFrames:
+      override.stableFrames != null ? override.stableFrames : d.stableFrames,
+    showHud: override.showHud != null ? override.showHud : d.showHud,
+    bindings: Array.isArray(override.bindings) ? override.bindings : d.bindings,
+  });
+}
+
+function storage() {
+  try {
+    return typeof localStorage !== "undefined" ? localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read the saved override (validated), or null if none / unavailable. */
+export function loadStored(key = STORAGE_KEY) {
+  const s = storage();
+  if (!s) return null;
+  try {
+    const raw = s.getItem(key);
+    if (!raw) return null;
+    return validateConfig(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function saveStored(cfg, key = STORAGE_KEY) {
+  const s = storage();
+  if (!s) return false;
+  try {
+    s.setItem(key, JSON.stringify(validateConfig(cfg)));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearStored(key = STORAGE_KEY) {
+  const s = storage();
+  if (!s) return false;
+  try {
+    s.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/mother-not-metaphor/src/fragmentary/control.js
+++ b/mother-not-metaphor/src/fragmentary/control.js
@@ -1,0 +1,192 @@
+/**
+ * fragmentary/control.js - dwell-based gesture control (pure, DOM-free).
+ *
+ * Turns a per-frame stream of finger states into deliberate actions. A pose must
+ * be (a) stable for a few frames, then (b) HELD for `dwellMs` before it fires -
+ * so switches take ~1-2s and never happen by accident. During the hold, `update`
+ * reports `progress` 0..1 so the UI can show a filling meter.
+ *
+ * A "binding" maps a finger pattern to an action:
+ *   { id, label, action:{type:'next'|'prev'|'goto'|'restart', index?}, fingers }
+ * where `fingers` is { thumb|index|middle|ring|pinky: 'any'|'up'|'down' }.
+ * The most specific matching binding wins (most non-'any' constraints).
+ *
+ * Firing rules:
+ *   - The FIRST stable pose only arms (never fires) so nothing jumps on load.
+ *   - A pose won't fire twice in a row; you must change pose (or drop the hand)
+ *     and re-make it. Dropping the hand ('none') clears the last-fired pose, so
+ *     the same gesture can be "pumped" to advance repeatedly.
+ */
+
+export const FINGERS = ["thumb", "index", "middle", "ring", "pinky"];
+
+export function patternKey(up) {
+  return up.map((b) => (b ? "1" : "0")).join("");
+}
+
+/** Does a finger pattern satisfy a binding's constraints? */
+export function matchBinding(up, binding) {
+  const f = (binding && binding.fingers) || {};
+  for (let i = 0; i < FINGERS.length; i++) {
+    const c = f[FINGERS[i]] || "any";
+    if (c === "any") continue;
+    if (!!up[i] !== (c === "up")) return false;
+  }
+  return true;
+}
+
+/** Count of non-'any' finger constraints (higher = more specific). */
+export function bindingSpecificity(binding) {
+  const f = (binding && binding.fingers) || {};
+  return FINGERS.reduce(
+    (n, name) => n + (f[name] && f[name] !== "any" ? 1 : 0),
+    0,
+  );
+}
+
+/** The most specific binding that matches `up`, or null. */
+export function pickBinding(up, bindings) {
+  let best = null;
+  let bestScore = -1;
+  for (const b of bindings || []) {
+    if (matchBinding(up, b)) {
+      const s = bindingSpecificity(b);
+      if (s > bestScore) {
+        bestScore = s;
+        best = b;
+      }
+    }
+  }
+  return best;
+}
+
+const positive = (v, dflt) => {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : dflt;
+};
+
+/**
+ * Create the control. Feed it `update(up, nowMs)` every frame; `up` is a 5-bool
+ * array, or null/undefined when no hand is present. Returns per-frame state:
+ *   { progress, firing, action, binding, stable, candidate, armed, ready }
+ *
+ * The key rule that makes switching DELIBERATE (no accidental fires from a hand
+ * that merely settles or rests): a matching pose can only fire once the hand has
+ * passed through a "reset" since it armed or last fired - i.e. it was absent
+ * ('none') OR held a neutral pose that matches no binding. So the motion is
+ * "relax, form the shape, hold" - a resting hand never advances on its own, and
+ * the very first pose (when the hand appears) only arms.
+ */
+export function createGestureControl(config = {}) {
+  const cfg = { dwellMs: 1500, stableFrames: 4, bindings: [], ...config };
+  cfg.dwellMs = positive(cfg.dwellMs, 1500);
+  cfg.stableFrames = Math.max(1, Math.round(positive(cfg.stableFrames, 4)));
+  let recent = [];
+  let armed = false; // has the hand been seen at all
+  let resetSeen = false; // passed a neutral/absent state since arming / last fire
+  let candKey = null;
+  let candSince = 0;
+
+  function reset() {
+    recent = [];
+    armed = false;
+    resetSeen = false;
+    candKey = null;
+    candSince = 0;
+  }
+
+  function setConfig(next) {
+    if (!next) return;
+    if (next.dwellMs != null) cfg.dwellMs = positive(next.dwellMs, cfg.dwellMs);
+    if (next.stableFrames != null)
+      cfg.stableFrames = Math.max(
+        1,
+        Math.round(positive(next.stableFrames, cfg.stableFrames)),
+      );
+    if (next.bindings != null) cfg.bindings = next.bindings;
+    if (recent.length > cfg.stableFrames)
+      recent = recent.slice(-cfg.stableFrames);
+  }
+
+  function frame(extra) {
+    return {
+      progress: 0,
+      firing: false,
+      action: null,
+      binding: null,
+      stable: null,
+      candidate: null,
+      armed,
+      ready: false,
+      ...extra,
+    };
+  }
+
+  function update(up, nowMs) {
+    const key = up ? patternKey(up) : "none";
+    recent.push(key);
+    if (recent.length > cfg.stableFrames) recent.shift();
+    const stable =
+      recent.length >= cfg.stableFrames && recent.every((k) => k === key)
+        ? key
+        : null;
+
+    if (stable === null) {
+      candKey = null;
+      return frame({});
+    }
+    if (stable === "none") {
+      resetSeen = true; // hand gone: a clean reset
+      candKey = null;
+      return frame({ stable: "none" });
+    }
+    if (!armed) {
+      armed = true; // the pose the hand appears in only arms; it never fires
+      resetSeen = false;
+      candKey = null;
+      return frame({ stable, armed: true });
+    }
+
+    const binding = pickBinding(up, cfg.bindings);
+    if (!binding) {
+      resetSeen = true; // a neutral (unbound) pose counts as a reset
+      candKey = null;
+      return frame({ stable });
+    }
+    if (!resetSeen) {
+      // recognized, but the hand hasn't reset since the last action - hold off
+      candKey = null;
+      return frame({ stable, binding });
+    }
+
+    if (candKey !== stable) {
+      candKey = stable;
+      candSince = nowMs;
+    }
+    const raw = (nowMs - candSince) / cfg.dwellMs;
+    const progress = Number.isFinite(raw) ? Math.min(1, Math.max(0, raw)) : 0;
+    if (progress >= 1) {
+      resetSeen = false; // consume: must reset before this (or any) pose fires again
+      candKey = null;
+      return frame({
+        progress: 1,
+        firing: true,
+        action: binding.action,
+        binding,
+        stable,
+        candidate: stable,
+        ready: true,
+      });
+    }
+    return frame({ progress, binding, stable, candidate: stable, ready: true });
+  }
+
+  return {
+    update,
+    reset,
+    setConfig,
+    get config() {
+      return cfg;
+    },
+  };
+}

--- a/mother-not-metaphor/src/fragmentary/fragmentary.css
+++ b/mother-not-metaphor/src/fragmentary/fragmentary.css
@@ -1,0 +1,114 @@
+/*
+ * fragmentary.css - shared styles for the Fragmentary gesture HUD (fx-* classes).
+ * Used by the piece (a bottom overlay) and the admin console. De Stijl neutrals;
+ * inherits --ink / --paper from the host page, with fallbacks.
+ */
+
+.fx-hud {
+  --fx-ink: var(--ink, #141414);
+  --fx-paper: var(--paper, #f3f3f1);
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid rgba(20, 20, 20, 0.85);
+  background: var(--fx-paper);
+  opacity: 0.55;
+  transition: opacity 0.3s ease;
+}
+.fx-hud.is-present {
+  opacity: 1;
+}
+
+.fx-bars {
+  display: flex;
+  gap: 5px;
+  align-items: flex-end;
+}
+.fx-bar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+}
+.fx-bar__track {
+  position: relative;
+  width: 9px;
+  height: 34px;
+  border: 1px solid rgba(20, 20, 20, 0.28);
+  background: transparent;
+  overflow: hidden;
+}
+.fx-bar__fill {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 0%;
+  background: rgba(20, 20, 20, 0.35);
+  transition: height 0.09s linear;
+}
+.fx-bar.is-up .fx-bar__fill {
+  background: var(--fx-ink);
+}
+.fx-bar__cap {
+  font-size: 9px;
+  line-height: 1;
+  opacity: 0.55;
+}
+.fx-bar.is-up .fx-bar__cap {
+  opacity: 1;
+}
+
+.fx-meter {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 64px;
+  height: 12px;
+  border: 1px solid rgba(20, 20, 20, 0.28);
+  overflow: hidden;
+}
+.fx-meter__fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0%;
+  background: var(--fx-ink);
+  transition: width 0.08s linear;
+}
+.fx-meter__label {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  padding-left: 6px;
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  color: var(--fx-ink);
+  mix-blend-mode: difference;
+  filter: invert(1);
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.fx-flash {
+  animation: fx-flash 0.5s ease;
+}
+@keyframes fx-flash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(20, 20, 20, 0.55);
+  }
+  100% {
+    box-shadow: 0 0 0 8px rgba(20, 20, 20, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fx-bar__fill,
+  .fx-meter__fill,
+  .fx-hud {
+    transition: none;
+  }
+  .fx-flash {
+    animation: none;
+  }
+}

--- a/mother-not-metaphor/src/fragmentary/gestures.js
+++ b/mother-not-metaphor/src/fragmentary/gestures.js
@@ -1,23 +1,26 @@
 /**
- * src/gestures.js - hand-shape signatures from landmarks (pure, DOM-free).
+ * fragmentary/gestures.js - hand-shape reading from landmarks (pure, DOM-free).
  *
+ * Part of "Fragmentary": a reusable gesture-control layer for hand-driven pieces.
  * MediaPipe Hand Landmarker gives 21 normalized landmarks { x, y, z } (x,y in
- * 0..1, origin top-left). We reduce a hand to a discrete *signature*: which
- * fingers are extended plus a coarse orientation bucket. When the stable
- * signature CHANGES (a new shape held for a few frames), the player advances to
- * the next moment - this is "when my fingers change shape, the layout changes".
+ * 0..1, origin top-left). Here we turn one hand into:
+ *   - `up`         : which fingers are extended  [thumb,index,middle,ring,pinky]
+ *   - `extensions` : a continuous 0..1 openness per finger (drives the HUD bars)
+ *   - `signature`  : a discrete comparable string for the pose
  *
  * Landmark indices (MediaPipe):
- *   0 wrist
- *   thumb  1 2 3 4 (4 tip)
- *   index  5 6 7 8 (8 tip, 6 pip)
- *   middle 9 10 11 12
- *   ring   13 14 15 16
- *   pinky  17 18 19 20
+ *   0 wrist; thumb 1-4 (4 tip); index 5-8 (8 tip, 6 pip); middle 9-12;
+ *   ring 13-16; pinky 17-20.
  */
+
+export const FINGER_NAMES = ["thumb", "index", "middle", "ring", "pinky"];
 
 const TIPS = { thumb: 4, index: 8, middle: 12, ring: 16, pinky: 20 };
 const PIPS = { index: 6, middle: 10, ring: 14, pinky: 18 };
+const MCPS = { thumb: 2, index: 5, middle: 9, ring: 13, pinky: 17 };
+
+const dist = (a, b) => Math.hypot(a.x - b.x, a.y - b.y);
+const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
 
 /**
  * Boolean array [thumb, index, middle, ring, pinky] of extended fingers.
@@ -28,8 +31,6 @@ export function fingersUp(landmarks, handedness = "Right") {
   if (!landmarks || landmarks.length < 21)
     return [false, false, false, false, false];
   const up = [];
-  // thumb: extended when its tip is far (in x) from the hand center, sign depends
-  // on which hand. Use index-finger MCP (5) as the reference.
   const ref = landmarks[5];
   const thumbTip = landmarks[TIPS.thumb];
   const dx = thumbTip.x - ref.x;
@@ -38,6 +39,26 @@ export function fingersUp(landmarks, handedness = "Right") {
     up.push(landmarks[TIPS[f]].y < landmarks[PIPS[f]].y - 0.02);
   }
   return up;
+}
+
+/**
+ * Continuous 0..1 openness per finger, for the visual bars. Uses tip-to-knuckle
+ * distance normalized by palm size, mapped through empirical curled/extended
+ * bounds so a fist reads near 0 and an open hand near 1.
+ */
+export function fingerExtensions(landmarks) {
+  if (!landmarks || landmarks.length < 21) return [0, 0, 0, 0, 0];
+  const palm = Math.max(1e-4, dist(landmarks[0], landmarks[9]));
+  const map = (raw, lo, hi) => clamp01((raw - lo) / (hi - lo));
+  const out = [];
+  // thumb: tip(4) spread from the index knuckle(5)
+  out.push(map(dist(landmarks[4], landmarks[5]) / palm, 0.28, 0.95));
+  for (const f of ["index", "middle", "ring", "pinky"]) {
+    out.push(
+      map(dist(landmarks[TIPS[f]], landmarks[MCPS[f]]) / palm, 0.35, 1.25),
+    );
+  }
+  return out;
 }
 
 /** Coarse pointing direction of the hand (wrist -> middle finger MCP). */
@@ -57,6 +78,28 @@ export function handSignature(landmarks, handedness = "Right") {
     .map((b) => (b ? "1" : "0"))
     .join("");
   return `${up}:${orientation(landmarks)}`;
+}
+
+/** One hand reduced to everything the control + HUD need. */
+export function handReading(landmarks, handedness = "Right") {
+  if (!landmarks || landmarks.length < 21) {
+    return {
+      present: false,
+      up: [false, false, false, false, false],
+      extensions: [0, 0, 0, 0, 0],
+      orientation: "none",
+      signature: "none",
+    };
+  }
+  const up = fingersUp(landmarks, handedness);
+  const orient = orientation(landmarks);
+  return {
+    present: true,
+    up,
+    extensions: fingerExtensions(landmarks),
+    orientation: orient,
+    signature: `${up.map((b) => (b ? "1" : "0")).join("")}:${orient}`,
+  };
 }
 
 /**

--- a/mother-not-metaphor/src/fragmentary/hud.js
+++ b/mother-not-metaphor/src/fragmentary/hud.js
@@ -1,0 +1,76 @@
+/**
+ * fragmentary/hud.js - the on-screen finger read-out (DOM).
+ *
+ * Five vertical bars, one per finger, that fill with each finger's detected
+ * extension and highlight when the finger is "up" - so you can SEE the hand being
+ * identified. Below them, a dwell meter fills over the hold time and labels the
+ * action about to fire. Styling lives in fragmentary.css (`fx-*` classes), shared
+ * by the piece and the admin console.
+ */
+
+import { FINGER_NAMES } from "./gestures.js";
+
+export function createFingerHud(
+  root,
+  { labels = FINGER_NAMES, reduced = false } = {},
+) {
+  root.classList.add("fx-hud");
+  root.replaceChildren();
+
+  const barsWrap = document.createElement("div");
+  barsWrap.className = "fx-bars";
+  const bars = labels.map((name) => {
+    const col = document.createElement("div");
+    col.className = "fx-bar";
+    const track = document.createElement("div");
+    track.className = "fx-bar__track";
+    const fill = document.createElement("div");
+    fill.className = "fx-bar__fill";
+    track.appendChild(fill);
+    const cap = document.createElement("div");
+    cap.className = "fx-bar__cap mono";
+    cap.textContent = name.charAt(0).toUpperCase();
+    col.append(track, cap);
+    barsWrap.appendChild(col);
+    return { col, fill };
+  });
+
+  const meter = document.createElement("div");
+  meter.className = "fx-meter";
+  const meterFill = document.createElement("div");
+  meterFill.className = "fx-meter__fill";
+  const meterLabel = document.createElement("div");
+  meterLabel.className = "fx-meter__label mono";
+  meter.append(meterFill, meterLabel);
+
+  root.append(barsWrap, meter);
+
+  function render(r = {}) {
+    const ext = r.extensions || [0, 0, 0, 0, 0];
+    const up = r.up || [false, false, false, false, false];
+    bars.forEach((b, i) => {
+      b.fill.style.height = `${Math.round(clamp01(ext[i]) * 100)}%`;
+      b.col.classList.toggle("is-up", !!up[i]);
+    });
+    meterFill.style.width = `${Math.round(clamp01(r.progress || 0) * 100)}%`;
+    meterLabel.textContent = r.label || "";
+    root.classList.toggle("is-present", !!r.present);
+    root.classList.toggle("is-arming", (r.progress || 0) > 0.01);
+  }
+
+  function flash() {
+    if (reduced) return;
+    root.classList.remove("fx-flash");
+    void root.offsetWidth; // restart the animation
+    root.classList.add("fx-flash");
+  }
+
+  function destroy() {
+    root.replaceChildren();
+    root.classList.remove("fx-hud", "is-present", "is-arming", "fx-flash");
+  }
+
+  return { render, flash, destroy };
+}
+
+const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);

--- a/mother-not-metaphor/src/gestures.js
+++ b/mother-not-metaphor/src/gestures.js
@@ -1,0 +1,77 @@
+/**
+ * src/gestures.js - hand-shape signatures from landmarks (pure, DOM-free).
+ *
+ * MediaPipe Hand Landmarker gives 21 normalized landmarks { x, y, z } (x,y in
+ * 0..1, origin top-left). We reduce a hand to a discrete *signature*: which
+ * fingers are extended plus a coarse orientation bucket. When the stable
+ * signature CHANGES (a new shape held for a few frames), the player advances to
+ * the next moment - this is "when my fingers change shape, the layout changes".
+ *
+ * Landmark indices (MediaPipe):
+ *   0 wrist
+ *   thumb  1 2 3 4 (4 tip)
+ *   index  5 6 7 8 (8 tip, 6 pip)
+ *   middle 9 10 11 12
+ *   ring   13 14 15 16
+ *   pinky  17 18 19 20
+ */
+
+const TIPS = { thumb: 4, index: 8, middle: 12, ring: 16, pinky: 20 };
+const PIPS = { index: 6, middle: 10, ring: 14, pinky: 18 };
+
+/**
+ * Boolean array [thumb, index, middle, ring, pinky] of extended fingers.
+ * For index..pinky: tip is above (smaller y) its pip joint. For the thumb we use
+ * horizontal distance from the index MCP, flipped by handedness.
+ */
+export function fingersUp(landmarks, handedness = "Right") {
+  if (!landmarks || landmarks.length < 21)
+    return [false, false, false, false, false];
+  const up = [];
+  // thumb: extended when its tip is far (in x) from the hand center, sign depends
+  // on which hand. Use index-finger MCP (5) as the reference.
+  const ref = landmarks[5];
+  const thumbTip = landmarks[TIPS.thumb];
+  const dx = thumbTip.x - ref.x;
+  up.push(handedness === "Right" ? dx < -0.04 : dx > 0.04);
+  for (const f of ["index", "middle", "ring", "pinky"]) {
+    up.push(landmarks[TIPS[f]].y < landmarks[PIPS[f]].y - 0.02);
+  }
+  return up;
+}
+
+/** Coarse pointing direction of the hand (wrist -> middle finger MCP). */
+export function orientation(landmarks) {
+  if (!landmarks || landmarks.length < 21) return "none";
+  const wrist = landmarks[0];
+  const mid = landmarks[9];
+  const dx = mid.x - wrist.x;
+  const dy = mid.y - wrist.y;
+  if (Math.abs(dx) > Math.abs(dy)) return dx > 0 ? "right" : "left";
+  return dy > 0 ? "down" : "up";
+}
+
+/** A discrete, comparable signature string for a hand pose. */
+export function handSignature(landmarks, handedness = "Right") {
+  const up = fingersUp(landmarks, handedness)
+    .map((b) => (b ? "1" : "0"))
+    .join("");
+  return `${up}:${orientation(landmarks)}`;
+}
+
+/**
+ * Given a rolling history of recent signatures (oldest first), return the
+ * signature if the last `n` are all identical (a stable pose), else null.
+ */
+export function stableSignature(history, n = 5) {
+  if (!Array.isArray(history) || history.length < n) return null;
+  const tail = history.slice(-n);
+  const first = tail[0];
+  if (first == null) return null;
+  return tail.every((s) => s === first) ? first : null;
+}
+
+/** True when we have two valid, different stable signatures. */
+export function signatureChanged(prev, next) {
+  return prev != null && next != null && prev !== next;
+}

--- a/mother-not-metaphor/src/hands.js
+++ b/mother-not-metaphor/src/hands.js
@@ -1,0 +1,61 @@
+/**
+ * src/hands.js - MediaPipe Hand Landmarker wrapper (DOM + the one CDN dep).
+ *
+ * This is the ONLY off-origin dependency in the piece: the tasks-vision runtime
+ * and the hand_landmarker model, both pinned. Everything is wrapped so any
+ * failure (offline, blocked, no GPU) is thrown and the caller degrades to the
+ * no-camera auto-play path. Detection runs entirely on-device.
+ */
+
+import { handSignature } from "./gestures.js";
+
+const TASKS_VISION =
+  "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.14";
+const WASM_ROOT = TASKS_VISION + "/wasm";
+const MODEL =
+  "https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task";
+
+export async function loadHandLandmarker() {
+  const vision = await import(TASKS_VISION);
+  const { FilesetResolver, HandLandmarker } = vision;
+  const fileset = await FilesetResolver.forVisionTasks(WASM_ROOT);
+  return HandLandmarker.createFromOptions(fileset, {
+    baseOptions: { modelAssetPath: MODEL, delegate: "GPU" },
+    numHands: 1,
+    runningMode: "VIDEO",
+  });
+}
+
+/**
+ * Run a per-frame detection loop, calling onSignature(signature, raw) each frame
+ * (signature is null when no hand is present). Returns a stop() function.
+ */
+export function trackHands(landmarker, video, onSignature) {
+  let stopped = false;
+  let lastVideoTime = -1;
+  const loop = () => {
+    if (stopped) return;
+    if (video.readyState >= 2 && video.currentTime !== lastVideoTime) {
+      lastVideoTime = video.currentTime;
+      try {
+        const res = landmarker.detectForVideo(video, performance.now());
+        if (res && res.landmarks && res.landmarks.length) {
+          const handed =
+            (res.handednesses && res.handednesses[0] && res.handednesses[0][0]
+              ? res.handednesses[0][0].categoryName
+              : "Right") || "Right";
+          onSignature(handSignature(res.landmarks[0], handed), res);
+        } else {
+          onSignature(null, res);
+        }
+      } catch {
+        // transient detection error; keep looping
+      }
+    }
+    requestAnimationFrame(loop);
+  };
+  requestAnimationFrame(loop);
+  return () => {
+    stopped = true;
+  };
+}

--- a/mother-not-metaphor/src/hands.js
+++ b/mother-not-metaphor/src/hands.js
@@ -7,7 +7,7 @@
  * no-camera auto-play path. Detection runs entirely on-device.
  */
 
-import { handSignature } from "./gestures.js";
+import { handReading } from "./fragmentary/gestures.js";
 
 const TASKS_VISION =
   "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.14";
@@ -27,10 +27,11 @@ export async function loadHandLandmarker() {
 }
 
 /**
- * Run a per-frame detection loop, calling onSignature(signature, raw) each frame
- * (signature is null when no hand is present). Returns a stop() function.
+ * Run a per-frame detection loop, calling onReading(reading) each frame where
+ * `reading` is a handReading() object ({ present, up, extensions, signature }).
+ * When no hand is visible, `present` is false. Returns a stop() function.
  */
-export function trackHands(landmarker, video, onSignature) {
+export function trackHands(landmarker, video, onReading) {
   let stopped = false;
   let lastVideoTime = -1;
   const loop = () => {
@@ -44,9 +45,9 @@ export function trackHands(landmarker, video, onSignature) {
             (res.handednesses && res.handednesses[0] && res.handednesses[0][0]
               ? res.handednesses[0][0].categoryName
               : "Right") || "Right";
-          onSignature(handSignature(res.landmarks[0], handed), res);
+          onReading(handReading(res.landmarks[0], handed), res);
         } else {
-          onSignature(null, res);
+          onReading(handReading(null), res);
         }
       } catch {
         // transient detection error; keep looping

--- a/mother-not-metaphor/src/illustration.js
+++ b/mother-not-metaphor/src/illustration.js
@@ -1,0 +1,94 @@
+/**
+ * src/illustration.js - the morphing SVG illustration (DOM).
+ *
+ * Renders a pool of <rect>s inside a 0..100 viewBox and tweens between frames
+ * using the pure morph engine. A single rAF drives the active tween; starting a
+ * new tween cancels the previous one. Honors prefers-reduced-motion by snapping.
+ */
+
+import { interpolateFrame, easeInOutCubic } from "./morph.js";
+
+const SVGNS = "http://www.w3.org/2000/svg";
+
+export function createIllustration(svgEl, palette, { reduced = false } = {}) {
+  const rects = [];
+  let current = []; // last rendered cells (hex fills)
+  let raf = 0;
+
+  const resolve = (key) => palette[key] || key;
+  const resolveFrame = (kf) =>
+    kf.map((c) => ({
+      x: c.x,
+      y: c.y,
+      w: c.w,
+      h: c.h,
+      fill: resolve(c.fill),
+      o: c.o == null ? 1 : c.o,
+    }));
+
+  function ensureRects(n) {
+    while (rects.length < n) {
+      const r = document.createElementNS(SVGNS, "rect");
+      r.setAttribute("shape-rendering", "crispEdges");
+      svgEl.appendChild(r);
+      rects.push(r);
+    }
+  }
+
+  function paint(cells) {
+    ensureRects(cells.length);
+    for (let i = 0; i < rects.length; i++) {
+      const c = cells[i];
+      if (!c || c.o <= 0 || c.w <= 0 || c.h <= 0) {
+        rects[i].setAttribute("opacity", "0");
+        continue;
+      }
+      rects[i].setAttribute("x", c.x.toFixed(2));
+      rects[i].setAttribute("y", c.y.toFixed(2));
+      rects[i].setAttribute("width", c.w.toFixed(2));
+      rects[i].setAttribute("height", c.h.toFixed(2));
+      rects[i].setAttribute("fill", c.fill);
+      rects[i].setAttribute("opacity", c.o.toFixed(3));
+    }
+    current = cells;
+  }
+
+  function snap(frame) {
+    cancelAnimationFrame(raf);
+    paint(resolveFrame(frame));
+  }
+
+  /** Tween from the currently shown cells to `frame` over `ms`. Resolves on done. */
+  function morphTo(frame, ms) {
+    const to = resolveFrame(frame);
+    const from = current.length ? current : to;
+    cancelAnimationFrame(raf);
+    if (reduced || ms <= 0) {
+      paint(to);
+      return Promise.resolve();
+    }
+    return new Promise((done) => {
+      const t0 = performance.now();
+      const tick = (now) => {
+        const t = Math.min(1, (now - t0) / ms);
+        paint(interpolateFrame(from, to, easeInOutCubic(t)));
+        if (t < 1) raf = requestAnimationFrame(tick);
+        else done();
+      };
+      raf = requestAnimationFrame(tick);
+    });
+  }
+
+  function destroy() {
+    cancelAnimationFrame(raf);
+  }
+
+  return {
+    snap,
+    morphTo,
+    destroy,
+    get current() {
+      return current;
+    },
+  };
+}

--- a/mother-not-metaphor/src/layout.js
+++ b/mother-not-metaphor/src/layout.js
@@ -1,0 +1,66 @@
+/**
+ * src/layout.js - the five layouts + smooth FLIP transitions (DOM).
+ *
+ * Each layout (L1..L5) is a CSS grid arrangement of the three component boxes
+ * (me / words / illus), selected via `data-layout` on the stage. Changing
+ * `data-layout` would snap the boxes to new positions, so we FLIP: measure each
+ * box First, change the layout (Last), Invert with a transform, then Play the
+ * transform away. Honors prefers-reduced-motion by snapping.
+ */
+
+const FLIP_MS = 620;
+
+export function createLayout(stageEl, boxes, { reduced = false } = {}) {
+  // boxes: { me, words, illus }
+  const items = Object.values(boxes);
+
+  let anims = [];
+
+  function set(layoutName) {
+    // cancel any in-flight transition so positions never get stuck mid-FLIP
+    for (const a of anims) a.cancel();
+    anims = [];
+
+    if (reduced || typeof items[0].animate !== "function") {
+      stageEl.setAttribute("data-layout", layoutName);
+      return;
+    }
+
+    const first = items.map((el) => el.getBoundingClientRect());
+    stageEl.setAttribute("data-layout", layoutName);
+    const last = items.map((el) => el.getBoundingClientRect());
+
+    items.forEach((el, i) => {
+      const f = first[i];
+      const l = last[i];
+      if (!f.width || !l.width) return; // box was hidden; nothing to invert
+      const dx = f.left - l.left;
+      const dy = f.top - l.top;
+      const sx = f.width / l.width;
+      const sy = f.height / l.height;
+      if (
+        Math.abs(dx) < 0.5 &&
+        Math.abs(dy) < 0.5 &&
+        Math.abs(sx - 1) < 0.01 &&
+        Math.abs(sy - 1) < 0.01
+      )
+        return;
+      // Web Animations API: fill defaults to "none", so nothing persists after
+      // the tween - the box settles into its real grid position by itself.
+      anims.push(
+        el.animate(
+          [
+            {
+              transformOrigin: "top left",
+              transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`,
+            },
+            { transformOrigin: "top left", transform: "none" },
+          ],
+          { duration: FLIP_MS, easing: "cubic-bezier(0.65, 0, 0.35, 1)" },
+        ),
+      );
+    });
+  }
+
+  return { set };
+}

--- a/mother-not-metaphor/src/main.js
+++ b/mother-not-metaphor/src/main.js
@@ -1,0 +1,119 @@
+/**
+ * src/main.js - boot. Loads the poem, wires the components, and chooses the
+ * input path: live hands when a camera + MediaPipe are available, otherwise the
+ * timed auto-play fallback (Instagram in-app browser, denied permission, etc.).
+ *
+ * Query params:
+ *   ?mode=auto   force the no-camera auto path (also skips the start tap)
+ *   ?mode=live   force the camera path
+ *   ?speed=N     multiply timing speed (tests / impatience)
+ *   ?loop=1      loop after the last moment
+ */
+
+import { createIllustration } from "./illustration.js";
+import { createWords } from "./words.js";
+import { createLayout } from "./layout.js";
+import { createPlayer } from "./player.js";
+import { startCamera, stopCamera } from "./camera.js";
+
+const params = new URLSearchParams(location.search);
+const forcedMode = params.get("mode");
+const speed = Math.max(0.1, parseFloat(params.get("speed") || "1") || 1);
+const loop = params.get("loop") === "1";
+const reduced = matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+const $ = (id) => document.getElementById(id);
+
+async function boot() {
+  const res = await fetch("data/poem.json");
+  const poem = await res.json();
+
+  document.documentElement.style.setProperty("--paper", poem.palette.paper);
+  document.documentElement.style.setProperty("--ink", poem.palette.ink);
+  document.title = poem.title;
+
+  const stage = $("stage");
+  const els = {
+    video: $("cam-video"),
+    svg: $("illus-svg"),
+    tag: $("words-tag"),
+    caption: $("words-caption"),
+    translation: $("words-translation"),
+    hint: $("hint"),
+    intro: $("intro"),
+    start: $("start"),
+    introNote: $("intro-note"),
+  };
+
+  const illustration = createIllustration(els.svg, poem.palette, { reduced });
+  const words = createWords(
+    { tag: els.tag, caption: els.caption, translation: els.translation },
+    { reduced },
+  );
+  const layout = createLayout(
+    stage,
+    { me: $("box-me"), words: $("box-words"), illus: $("box-illus") },
+    { reduced },
+  );
+  const player = createPlayer({
+    poem,
+    illustration,
+    words,
+    layout,
+    hint: els.hint,
+    stage,
+    speed,
+    loop,
+  });
+
+  // expose for tests + debugging
+  window.MNM = {
+    state: () => player.state(),
+    next: () => player.advance(),
+    goTo: (i) => player.goTo(i),
+    still: (i, k) => player.still(i, k),
+    poem,
+  };
+
+  async function goLive() {
+    try {
+      await startCamera(els.video);
+      stage.setAttribute("data-camera", "1");
+      // load hand tracking lazily; if it fails we still show the camera + auto-play
+      const { loadHandLandmarker, trackHands } = await import("./hands.js");
+      const landmarker = await loadHandLandmarker();
+      trackHands(landmarker, els.video, (sig) => player.onSignature(sig));
+      player.start("live");
+      return true;
+    } catch (err) {
+      stopCamera(els.video);
+      stage.removeAttribute("data-camera");
+      return false;
+    }
+  }
+
+  function goAuto() {
+    player.start("auto");
+  }
+
+  async function begin() {
+    els.intro.setAttribute("hidden", "");
+    if (forcedMode === "auto") return goAuto();
+    const live = await goLive();
+    if (!live) goAuto();
+  }
+
+  if (forcedMode === "auto") {
+    // deterministic path: no user gesture needed (no camera requested)
+    begin();
+  } else {
+    els.start.addEventListener("click", begin, { once: true });
+    els.intro.removeAttribute("hidden");
+  }
+}
+
+boot().catch((e) => {
+  const hint = $("hint");
+  if (hint) hint.textContent = "could not load";
+  console.error("[mother-not-metaphor] boot failed", e);
+});

--- a/mother-not-metaphor/src/main.js
+++ b/mother-not-metaphor/src/main.js
@@ -8,6 +8,7 @@
  *   ?mode=live   force the camera path
  *   ?speed=N     multiply timing speed (tests / impatience)
  *   ?loop=1      loop after the last moment
+ *   ?hud=off     hide the finger HUD (clean capture)
  */
 
 import { createIllustration } from "./illustration.js";
@@ -15,18 +16,39 @@ import { createWords } from "./words.js";
 import { createLayout } from "./layout.js";
 import { createPlayer } from "./player.js";
 import { startCamera, stopCamera } from "./camera.js";
+import { createGestureControl } from "./fragmentary/control.js";
+import { createFingerHud } from "./fragmentary/hud.js";
+import {
+  validateConfig,
+  mergeConfig,
+  loadStored,
+} from "./fragmentary/config.js";
 
 const params = new URLSearchParams(location.search);
 const forcedMode = params.get("mode");
 const speed = Math.max(0.1, parseFloat(params.get("speed") || "1") || 1);
 const loop = params.get("loop") === "1";
+const hudParam = params.get("hud");
 const reduced = matchMedia("(prefers-reduced-motion: reduce)").matches;
 
 const $ = (id) => document.getElementById(id);
 
+async function loadGestureConfig() {
+  let defaults = {};
+  try {
+    defaults = await (await fetch("data/gestures.json")).json();
+  } catch {
+    // fall back to the validator's built-in defaults
+  }
+  // an admin-saved override (localStorage) wins over the shipped default
+  return mergeConfig(validateConfig(defaults), loadStored());
+}
+
 async function boot() {
-  const res = await fetch("data/poem.json");
-  const poem = await res.json();
+  const [poem, gestureConfig] = await Promise.all([
+    fetch("data/poem.json").then((r) => r.json()),
+    loadGestureConfig(),
+  ]);
 
   document.documentElement.style.setProperty("--paper", poem.palette.paper);
   document.documentElement.style.setProperty("--ink", poem.palette.ink);
@@ -40,9 +62,9 @@ async function boot() {
     caption: $("words-caption"),
     translation: $("words-translation"),
     hint: $("hint"),
+    hud: $("hud-panel"),
     intro: $("intro"),
     start: $("start"),
-    introNote: $("intro-note"),
   };
 
   const illustration = createIllustration(els.svg, poem.palette, { reduced });
@@ -55,6 +77,16 @@ async function boot() {
     { me: $("box-me"), words: $("box-words"), illus: $("box-illus") },
     { reduced },
   );
+  const control = createGestureControl({
+    dwellMs: gestureConfig.dwellMs,
+    stableFrames: gestureConfig.stableFrames,
+    bindings: gestureConfig.bindings,
+  });
+  const hud = createFingerHud(els.hud, { reduced });
+
+  const showHud = hudParam !== "off" && gestureConfig.showHud;
+  stage.setAttribute("data-hud", "off"); // shown once live hand tracking starts
+
   const player = createPlayer({
     poem,
     illustration,
@@ -62,6 +94,8 @@ async function boot() {
     layout,
     hint: els.hint,
     stage,
+    control,
+    hud,
     speed,
     loop,
   });
@@ -72,6 +106,9 @@ async function boot() {
     next: () => player.advance(),
     goTo: (i) => player.goTo(i),
     still: (i, k) => player.still(i, k),
+    feed: (reading, now) =>
+      player.feed(reading, now == null ? performance.now() : now),
+    config: gestureConfig,
     poem,
   };
 
@@ -82,10 +119,13 @@ async function boot() {
       // load hand tracking lazily; if it fails we still show the camera + auto-play
       const { loadHandLandmarker, trackHands } = await import("./hands.js");
       const landmarker = await loadHandLandmarker();
-      trackHands(landmarker, els.video, (sig) => player.onSignature(sig));
+      trackHands(landmarker, els.video, (reading) =>
+        player.feed(reading, performance.now()),
+      );
+      if (showHud) stage.setAttribute("data-hud", "on");
       player.start("live");
       return true;
-    } catch (err) {
+    } catch {
       stopCamera(els.video);
       stage.removeAttribute("data-camera");
       return false;
@@ -104,7 +144,6 @@ async function boot() {
   }
 
   if (forcedMode === "auto") {
-    // deterministic path: no user gesture needed (no camera requested)
     begin();
   } else {
     els.start.addEventListener("click", begin, { once: true });

--- a/mother-not-metaphor/src/morph.js
+++ b/mother-not-metaphor/src/morph.js
@@ -1,0 +1,73 @@
+/**
+ * src/morph.js - geometric frame interpolation (pure, DOM-free).
+ *
+ * An illustration "frame" is an array of cells (rectangles):
+ *   { x, y, w, h, fill, o }   // fill is a #rrggbb hex; o is opacity 0..1
+ *
+ * To morph frame A -> frame B we:
+ *   1. pad the shorter frame so both have the same length (extra cells are born
+ *      from / die into a point, so counts can change without popping);
+ *   2. interpolate each cell pair: geometry linearly, color through OKLab.
+ *
+ * The renderer feeds an already-eased t (see easeInOutCubic) for natural motion.
+ */
+
+import { lerpColor } from "./color.js";
+
+const lerp = (a, b, t) => a + (b - a) * t;
+
+export function easeInOutCubic(t) {
+  if (t <= 0) return 0;
+  if (t >= 1) return 1;
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+}
+
+/** A zero-size, transparent cell at the center of `target`, in its eventual color. */
+export function ghostOf(target) {
+  return {
+    x: target.x + target.w / 2,
+    y: target.y + target.h / 2,
+    w: 0,
+    h: 0,
+    fill: target.fill,
+    o: 0,
+  };
+}
+
+/** Pad [a, b] to equal length using ghosts derived from the longer frame. */
+export function padPair(a, b) {
+  const a2 = a.map(normalize);
+  const b2 = b.map(normalize);
+  while (a2.length < b2.length) a2.push(ghostOf(b2[a2.length]));
+  while (b2.length < a2.length) b2.push(ghostOf(a2[b2.length]));
+  return [a2, b2];
+}
+
+function normalize(c) {
+  return {
+    x: c.x,
+    y: c.y,
+    w: c.w,
+    h: c.h,
+    fill: c.fill,
+    o: c.o == null ? 1 : c.o,
+  };
+}
+
+/** Interpolate a single cell pair at eased t. */
+export function lerpCell(ca, cb, t) {
+  return {
+    x: lerp(ca.x, cb.x, t),
+    y: lerp(ca.y, cb.y, t),
+    w: lerp(ca.w, cb.w, t),
+    h: lerp(ca.h, cb.h, t),
+    fill: lerpColor(ca.fill, cb.fill, t),
+    o: lerp(ca.o == null ? 1 : ca.o, cb.o == null ? 1 : cb.o, t),
+  };
+}
+
+/** Interpolate two frames at t in [0,1]. Returns a padded array of cells. */
+export function interpolateFrame(frameA, frameB, t) {
+  const [a, b] = padPair(frameA, frameB);
+  return a.map((ca, i) => lerpCell(ca, b[i], t));
+}

--- a/mother-not-metaphor/src/pacing.js
+++ b/mother-not-metaphor/src/pacing.js
@@ -1,0 +1,50 @@
+/**
+ * src/pacing.js - speaking-rate timing (pure, DOM-free).
+ *
+ * The illustration morphs are paced to how long a line takes to say. We derive a
+ * moment's duration from its text length and a per-character rate, then spread the
+ * moment's keyframes across that duration. The same duration drives the
+ * typewriter and the no-camera auto-advance timer.
+ */
+
+const clamp = (v, lo, hi) => (v < lo ? lo : v > hi ? hi : v);
+
+export const DEFAULT_PACING = {
+  msPerChar: 55, // ~ unhurried speech
+  minMomentMs: 4200,
+  maxMomentMs: 13000,
+  morphMs: 560, // length of a single keyframe transition
+};
+
+/** How long a moment lasts, from its text and the pacing config. */
+export function momentDurationMs(text, pacing = DEFAULT_PACING) {
+  const { msPerChar, minMomentMs, maxMomentMs } = {
+    ...DEFAULT_PACING,
+    ...pacing,
+  };
+  const raw = (text ? text.length : 0) * msPerChar;
+  return clamp(raw, minMomentMs, maxMomentMs);
+}
+
+/**
+ * When each keyframe transition should start, spread across the moment.
+ * Returns `count` entries: keyframe 0 is reached at t=0; each later keyframe
+ * transitions over `morphMs`, then holds until the next. All starts are in
+ * [0, duration] and strictly ascending.
+ */
+export function scheduleKeyframes(
+  count,
+  duration,
+  morphMs = DEFAULT_PACING.morphMs,
+) {
+  if (count <= 0) return [];
+  if (count === 1) return [{ index: 0, start: 0, morphMs }];
+  // Leave the last segment as a hold so the final frame is seen before advancing.
+  const segment = duration / count;
+  const out = [];
+  for (let i = 0; i < count; i++) {
+    const start = i === 0 ? 0 : Math.min(i * segment, duration);
+    out.push({ index: i, start, morphMs: Math.min(morphMs, segment) });
+  }
+  return out;
+}

--- a/mother-not-metaphor/src/player.js
+++ b/mother-not-metaphor/src/player.js
@@ -1,0 +1,159 @@
+/**
+ * src/player.js - the poem orchestration (DOM).
+ *
+ * Drives the moment-by-moment performance:
+ *   - sets the layout for each moment (FLIP transition);
+ *   - reveals the words (typewriter) over the moment's duration;
+ *   - paces the illustration keyframe morphs across that duration;
+ *   - advances between moments either by a hand-shape change (live) or a timer
+ *     (auto / no-camera fallback).
+ *
+ * Timing is pure-derived (pacing.js); a `speed` multiplier accelerates tests.
+ */
+
+import { momentDurationMs, scheduleKeyframes } from "./pacing.js";
+import { stableSignature, signatureChanged } from "./gestures.js";
+
+export function createPlayer({
+  poem,
+  illustration,
+  words,
+  layout,
+  hint,
+  stage,
+  speed = 1,
+  loop = false,
+}) {
+  const moments = poem.moments;
+  const pacing = poem.pacing;
+  let index = -1;
+  let mode = "auto";
+  let timers = [];
+  let history = [];
+  let baseline = null; // last stable hand signature we acted on
+  let advancing = false;
+
+  const clearTimers = () => {
+    for (const t of timers) clearTimeout(t);
+    timers = [];
+  };
+
+  function durationFor(m) {
+    return Math.max(900, momentDurationMs(m.original, pacing) / speed);
+  }
+
+  function goToMoment(i) {
+    if (i < 0 || i >= moments.length) return;
+    clearTimers();
+    index = i;
+    const m = moments[i];
+    const dur = durationFor(m);
+    const morphMs = Math.max(120, pacing.morphMs / speed);
+
+    layout.set(m.layout);
+    words.start(m, dur);
+
+    const kfs = m.illustration.keyframes;
+    // cross-moment morph into this moment's first keyframe
+    illustration.morphTo(kfs[0], morphMs);
+    // pace the within-moment keyframe morphs across the moment
+    const sched = scheduleKeyframes(kfs.length, dur, morphMs);
+    for (let k = 1; k < kfs.length; k++) {
+      timers.push(
+        setTimeout(
+          () => illustration.morphTo(kfs[k], sched[k].morphMs),
+          sched[k].start,
+        ),
+      );
+    }
+
+    if (mode === "auto") {
+      timers.push(setTimeout(() => advance(), dur));
+    }
+    updateHint();
+    stage.setAttribute("data-moment", m.id);
+  }
+
+  function advance() {
+    if (advancing) return;
+    if (index < moments.length - 1) {
+      goToMoment(index + 1);
+    } else if (loop) {
+      goToMoment(0);
+    } else {
+      // hold on the final moment
+      clearTimers();
+      stage.setAttribute("data-done", "1");
+      updateHint();
+    }
+  }
+
+  function updateHint() {
+    if (!hint) return;
+    const pos = `${index + 1} / ${moments.length}`;
+    if (stage.getAttribute("data-done")) hint.textContent = `${pos} · end`;
+    else if (mode === "live") hint.textContent = `${pos} · change your hands`;
+    else hint.textContent = `${pos}`;
+  }
+
+  // --- live gesture input ---------------------------------------------------
+  function onSignature(sig) {
+    if (mode !== "live") return;
+    history.push(sig);
+    if (history.length > 8) history.shift();
+    const stable = stableSignature(history, 5);
+    if (!stable) return;
+    if (baseline == null) {
+      baseline = stable; // arm without advancing on the first pose
+      return;
+    }
+    if (signatureChanged(baseline, stable)) {
+      baseline = stable;
+      advance();
+    }
+  }
+
+  function start(startMode) {
+    mode = startMode === "live" ? "live" : "auto";
+    stage.removeAttribute("data-done");
+    history = [];
+    baseline = null;
+    goToMoment(0);
+  }
+
+  function destroy() {
+    clearTimers();
+    advancing = true;
+  }
+
+  // Freeze on a moment at a given keyframe (default: its last) with no timers.
+  // Used for debugging and screenshots; not part of the performance flow.
+  function still(i, k = -1) {
+    if (i < 0 || i >= moments.length) return;
+    clearTimers();
+    index = i;
+    const m = moments[i];
+    const kfs = m.illustration.keyframes;
+    const kf = kfs[k < 0 ? kfs.length - 1 : Math.min(k, kfs.length - 1)];
+    layout.set(m.layout);
+    words.showFull(m);
+    illustration.snap(kf);
+    stage.setAttribute("data-moment", m.id);
+    updateHint();
+  }
+
+  return {
+    start,
+    advance,
+    onSignature,
+    destroy,
+    still,
+    goTo: goToMoment,
+    state: () => ({
+      index,
+      mode,
+      moment: index >= 0 ? moments[index].id : null,
+      total: moments.length,
+    }),
+  };
+}

--- a/mother-not-metaphor/src/player.js
+++ b/mother-not-metaphor/src/player.js
@@ -5,14 +5,13 @@
  *   - sets the layout for each moment (FLIP transition);
  *   - reveals the words (typewriter) over the moment's duration;
  *   - paces the illustration keyframe morphs across that duration;
- *   - advances between moments either by a hand-shape change (live) or a timer
- *     (auto / no-camera fallback).
+ *   - advances between moments either by a deliberate hand gesture (live, via the
+ *     Fragmentary dwell control) or a timer (auto / no-camera fallback).
  *
  * Timing is pure-derived (pacing.js); a `speed` multiplier accelerates tests.
  */
 
 import { momentDurationMs, scheduleKeyframes } from "./pacing.js";
-import { stableSignature, signatureChanged } from "./gestures.js";
 
 export function createPlayer({
   poem,
@@ -21,6 +20,8 @@ export function createPlayer({
   layout,
   hint,
   stage,
+  control = null,
+  hud = null,
   speed = 1,
   loop = false,
 }) {
@@ -29,9 +30,7 @@ export function createPlayer({
   let index = -1;
   let mode = "auto";
   let timers = [];
-  let history = [];
-  let baseline = null; // last stable hand signature we acted on
-  let advancing = false;
+  let destroyed = false;
 
   const clearTimers = () => {
     for (const t of timers) clearTimeout(t);
@@ -43,8 +42,9 @@ export function createPlayer({
   }
 
   function goToMoment(i) {
-    if (i < 0 || i >= moments.length) return;
+    if (destroyed || i < 0 || i >= moments.length) return;
     clearTimers();
+    stage.removeAttribute("data-done");
     index = i;
     const m = moments[i];
     const dur = durationFor(m);
@@ -54,9 +54,7 @@ export function createPlayer({
     words.start(m, dur);
 
     const kfs = m.illustration.keyframes;
-    // cross-moment morph into this moment's first keyframe
     illustration.morphTo(kfs[0], morphMs);
-    // pace the within-moment keyframe morphs across the moment
     const sched = scheduleKeyframes(kfs.length, dur, morphMs);
     for (let k = 1; k < kfs.length; k++) {
       timers.push(
@@ -67,24 +65,40 @@ export function createPlayer({
       );
     }
 
-    if (mode === "auto") {
-      timers.push(setTimeout(() => advance(), dur));
-    }
+    if (mode === "auto") timers.push(setTimeout(() => advance(), dur));
     updateHint();
     stage.setAttribute("data-moment", m.id);
   }
 
   function advance() {
-    if (advancing) return;
-    if (index < moments.length - 1) {
-      goToMoment(index + 1);
-    } else if (loop) {
-      goToMoment(0);
-    } else {
-      // hold on the final moment
+    if (destroyed) return;
+    if (index < moments.length - 1) goToMoment(index + 1);
+    else if (loop) goToMoment(0);
+    else {
       clearTimers();
       stage.setAttribute("data-done", "1");
       updateHint();
+    }
+  }
+
+  /** Run a Fragmentary action from a fired gesture binding. */
+  function runAction(action) {
+    if (!action) return;
+    switch (action.type) {
+      case "prev":
+        if (index > 0) goToMoment(index - 1);
+        break;
+      case "goto":
+        goToMoment(
+          Math.max(0, Math.min(moments.length - 1, action.index || 0)),
+        );
+        break;
+      case "restart":
+        goToMoment(0);
+        break;
+      case "next":
+      default:
+        advance();
     }
   }
 
@@ -92,42 +106,53 @@ export function createPlayer({
     if (!hint) return;
     const pos = `${index + 1} / ${moments.length}`;
     if (stage.getAttribute("data-done")) hint.textContent = `${pos} · end`;
-    else if (mode === "live") hint.textContent = `${pos} · change your hands`;
-    else hint.textContent = `${pos}`;
+    else if (mode === "live")
+      hint.textContent = `${pos} · hold a new hand shape`;
+    else hint.textContent = pos;
   }
 
-  // --- live gesture input ---------------------------------------------------
-  function onSignature(sig) {
-    if (mode !== "live") return;
-    history.push(sig);
-    if (history.length > 8) history.shift();
-    const stable = stableSignature(history, 5);
-    if (!stable) return;
-    if (baseline == null) {
-      baseline = stable; // arm without advancing on the first pose
-      return;
+  /**
+   * Per-frame hand input: update the dwell control, paint the HUD, and run an
+   * action if a gesture completed its hold. Called by the hand tracker (live) or
+   * directly by tests via window.MNM.feed.
+   */
+  function feed(reading, nowMs) {
+    if (destroyed || !control) return null;
+    const r = reading || {
+      present: false,
+      up: null,
+      extensions: [0, 0, 0, 0, 0],
+    };
+    const res = control.update(r.present ? r.up : null, nowMs);
+    if (hud) {
+      hud.render({
+        present: r.present,
+        up: r.up || [false, false, false, false, false],
+        extensions: r.extensions || [0, 0, 0, 0, 0],
+        progress: res.progress,
+        label: res.binding ? res.binding.label : "",
+      });
     }
-    if (signatureChanged(baseline, stable)) {
-      baseline = stable;
-      advance();
+    if (res.firing) {
+      if (hud) hud.flash();
+      runAction(res.action);
     }
+    return res;
   }
 
   function start(startMode) {
     mode = startMode === "live" ? "live" : "auto";
     stage.removeAttribute("data-done");
-    history = [];
-    baseline = null;
+    if (control) control.reset();
     goToMoment(0);
   }
 
   function destroy() {
+    destroyed = true;
     clearTimers();
-    advancing = true;
   }
 
-  // Freeze on a moment at a given keyframe (default: its last) with no timers.
-  // Used for debugging and screenshots; not part of the performance flow.
+  // Freeze on a moment at a given keyframe (default: last), no timers. Debug only.
   function still(i, k = -1) {
     if (i < 0 || i >= moments.length) return;
     clearTimers();
@@ -145,7 +170,7 @@ export function createPlayer({
   return {
     start,
     advance,
-    onSignature,
+    feed,
     destroy,
     still,
     goTo: goToMoment,

--- a/mother-not-metaphor/src/words.js
+++ b/mother-not-metaphor/src/words.js
@@ -1,0 +1,74 @@
+/**
+ * src/words.js - the live-transcription words component (DOM).
+ *
+ * The pre-written line is revealed character by character, like live captions
+ * being transcribed. For non-English moments a translation line fades in beneath
+ * the original once the original is mostly revealed. The original text is always
+ * the verbatim string from the poem - nothing is ever mis-heard.
+ */
+
+export function createWords(els, { reduced = false } = {}) {
+  // els: { tag, caption, translation }
+  let raf = 0;
+
+  function clear() {
+    cancelAnimationFrame(raf);
+    els.caption.textContent = "";
+    els.translation.textContent = "";
+    els.translation.classList.remove("is-shown");
+  }
+
+  /**
+   * Reveal a moment's words over `durationMs`. The original finishes typing at
+   * ~70% of the moment so it can be read; the translation (if any) fades in at
+   * ~55%.
+   */
+  function start(moment, durationMs) {
+    cancelAnimationFrame(raf);
+    els.tag.textContent = `[${moment.lang}]`;
+    els.translation.classList.remove("is-shown");
+    els.translation.textContent = moment.english || "";
+
+    const text = moment.original;
+    if (reduced) {
+      els.caption.textContent = text;
+      if (moment.english) els.translation.classList.add("is-shown");
+      return;
+    }
+
+    els.caption.textContent = "";
+    const typeMs = Math.max(800, durationMs * 0.7);
+    const t0 = performance.now();
+    let translationShown = false;
+    const tick = (now) => {
+      const p = Math.min(1, (now - t0) / typeMs);
+      const n = Math.floor(p * text.length);
+      els.caption.textContent = text.slice(0, n);
+      if (!translationShown && moment.english && p >= 0.55) {
+        els.translation.classList.add("is-shown");
+        translationShown = true;
+      }
+      if (p < 1) raf = requestAnimationFrame(tick);
+      else {
+        els.caption.textContent = text;
+        if (moment.english) els.translation.classList.add("is-shown");
+      }
+    };
+    raf = requestAnimationFrame(tick);
+  }
+
+  /** Show a moment's words fully, immediately (debug / reduced paths). */
+  function showFull(moment) {
+    cancelAnimationFrame(raf);
+    els.tag.textContent = `[${moment.lang}]`;
+    els.caption.textContent = moment.original;
+    els.translation.textContent = moment.english || "";
+    els.translation.classList.toggle("is-shown", !!moment.english);
+  }
+
+  function destroy() {
+    cancelAnimationFrame(raf);
+  }
+
+  return { start, clear, showFull, destroy };
+}

--- a/mother-not-metaphor/styles.css
+++ b/mother-not-metaphor/styles.css
@@ -1,0 +1,322 @@
+/*
+ * mother-not-metaphor - styles
+ *
+ * A phone-sized portrait stage holding three components (me / words /
+ * illustration) arranged by five layouts (L1..L5). De Stijl palette, hairline
+ * borders, no shadows / gradients / rounded corners. Mobile fills the screen;
+ * wider screens show a 4:5 card (Instagram portrait) so nothing overflows.
+ */
+
+:root {
+  --paper: #f3f3f1;
+  --ink: #141414;
+  --sans: "Helvetica Neue", Helvetica, Arial, "Segoe UI", system-ui, sans-serif;
+  --mono: ui-monospace, "SF Mono", "Menlo", "Consolas", monospace;
+
+  --line: rgba(20, 20, 20, 0.85);
+  --line-soft: rgba(20, 20, 20, 0.18);
+  --gap: clamp(6px, 1.8vmin, 14px);
+  --pad: clamp(8px, 2.2vmin, 18px);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--sans);
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.mono {
+  font-family: var(--mono);
+  font-variant-ligatures: none;
+}
+
+/* --- the stage ----------------------------------------------------------- */
+.stage {
+  position: relative;
+  width: 100vw;
+  height: 100dvh;
+  background: var(--paper);
+  overflow: hidden;
+  display: grid;
+  gap: var(--gap);
+  padding: var(--pad);
+}
+
+/* wider than tall: show a 4:5 Instagram-portrait card, centered */
+@media (min-aspect-ratio: 1/1) {
+  .stage {
+    width: auto;
+    height: 94dvh;
+    aspect-ratio: 4 / 5;
+    border: 1px solid var(--line-soft);
+  }
+}
+
+/* --- the three component boxes ------------------------------------------- */
+.box {
+  position: relative;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  will-change: transform;
+}
+
+#box-me {
+  grid-area: me;
+}
+#box-words {
+  grid-area: words;
+}
+#box-illus {
+  grid-area: illus;
+}
+
+.box-label {
+  position: absolute;
+  left: 7px;
+  top: 6px;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--ink);
+  opacity: 0.38;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* --- the five layouts ---------------------------------------------------- */
+.stage[data-layout="L1"] {
+  grid-template-columns: 38% 1fr;
+  grid-template-rows: 1fr 1fr;
+  grid-template-areas: "me illus" "words words";
+}
+.stage[data-layout="L2"] {
+  grid-template-columns: 1fr 36%;
+  grid-template-rows: 28% 38% 1fr;
+  grid-template-areas: "illus me" "illus ." "words words";
+}
+.stage[data-layout="L3"] {
+  grid-template-columns: 1fr;
+  grid-template-rows: 42% 32% 1fr;
+  grid-template-areas: "illus" "words" "me";
+}
+.stage[data-layout="L4"] {
+  grid-template-columns: 1fr 34%;
+  grid-template-rows: 30% 22% 1fr;
+  grid-template-areas: "words me" "words ." "illus illus";
+}
+.stage[data-layout="L5"] {
+  grid-template-columns: 36% 1fr;
+  grid-template-rows: 34% 1fr;
+  grid-template-areas: "me words" "illus illus";
+}
+
+/* --- ME: the camera ------------------------------------------------------ */
+.cam-video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* mirror, like a front camera */
+  background: var(--ink);
+  display: none;
+}
+.stage[data-camera="1"] .cam-video {
+  display: block;
+}
+.cam-fallback {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  text-align: center;
+  padding: 10px;
+}
+.stage[data-camera="1"] .cam-fallback {
+  display: none;
+}
+.cam-fallback__name {
+  font-size: clamp(13px, 3.4vmin, 22px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.cam-fallback__sub {
+  font-size: 10px;
+  opacity: 0.5;
+}
+
+/* --- WORDS: live transcription ------------------------------------------- */
+.box--words {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: clamp(6px, 1.4vmin, 12px);
+  padding: clamp(12px, 3.2vmin, 26px);
+}
+.words-tag {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  opacity: 0.55;
+}
+.words-caption {
+  margin: 0;
+  font-size: clamp(15px, 4.1vmin, 30px);
+  line-height: 1.3;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  max-width: 38ch;
+}
+.words-translation {
+  margin: 0;
+  font-size: clamp(11px, 2.4vmin, 16px);
+  line-height: 1.4;
+  color: var(--ink);
+  opacity: 0;
+  max-width: 44ch;
+  transition: opacity 0.6s ease;
+}
+.words-translation.is-shown {
+  opacity: 0.5;
+}
+.caret {
+  position: absolute;
+  right: 12px;
+  bottom: 10px;
+  width: 9px;
+  height: 16px;
+  background: var(--ink);
+  opacity: 0.7;
+  animation: blink 1.1s steps(1) infinite;
+}
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+/* --- ILLUSTRATION -------------------------------------------------------- */
+.illus-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* --- hint + back --------------------------------------------------------- */
+.hint {
+  position: absolute;
+  left: 50%;
+  bottom: calc(var(--pad) + 4px);
+  transform: translateX(-50%);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  opacity: 0.42;
+  z-index: 3;
+  pointer-events: none;
+}
+.back {
+  position: fixed;
+  right: 10px;
+  bottom: 8px;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--ink);
+  opacity: 0.32;
+  text-decoration: none;
+  z-index: 5;
+}
+.back:hover {
+  opacity: 0.7;
+}
+
+/* --- intro gate ---------------------------------------------------------- */
+.intro {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  background: var(--paper);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8vmin;
+}
+.intro[hidden] {
+  display: none;
+}
+.intro__inner {
+  max-width: 30ch;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  align-items: center;
+}
+.intro__title {
+  margin: 0;
+  font-size: clamp(22px, 7vmin, 44px);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+}
+.intro__note {
+  margin: 0;
+  font-size: clamp(12px, 2.6vmin, 15px);
+  line-height: 1.5;
+  opacity: 0.62;
+}
+.intro__start {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--line);
+  padding: 12px 26px;
+  cursor: pointer;
+  transition: opacity 0.3s ease;
+  min-height: 44px;
+}
+.intro__start:hover {
+  opacity: 0.7;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .caret,
+  .words-translation {
+    animation: none;
+    transition: none;
+  }
+  .box {
+    will-change: auto;
+  }
+}

--- a/mother-not-metaphor/styles.css
+++ b/mother-not-metaphor/styles.css
@@ -244,6 +244,27 @@ body {
   z-index: 3;
   pointer-events: none;
 }
+
+/* Fragmentary finger HUD - a bottom overlay, shown only in gesture mode */
+.hud-panel {
+  position: absolute;
+  left: 50%;
+  bottom: calc(var(--pad) + 24px);
+  transform: translateX(-50%);
+  z-index: 4;
+  display: none;
+  max-width: calc(100% - 2 * var(--pad));
+  pointer-events: none;
+}
+.stage[data-hud="on"] .hud-panel {
+  display: flex;
+}
+/* Reserve a strip at the bottom for the HUD so no component (e.g. the words box
+   on L1/L2) is ever hidden behind it - the whole grid sits above the HUD band. */
+.stage[data-hud="on"] {
+  padding-bottom: calc(var(--pad) + 92px);
+}
+
 .back {
   position: fixed;
   right: 10px;

--- a/mother-not-metaphor/tasks/prd-mother-not-metaphor.md
+++ b/mother-not-metaphor/tasks/prd-mother-not-metaphor.md
@@ -1,0 +1,194 @@
+# PRD: mother, not metaphor
+
+## Overview
+
+`mother-not-metaphor` is a mobile-native generative poem piece living at
+`oulipo.xyz/mother-not-metaphor`, featured on the Kitchen Lab landing page. It
+renders a five-moment poem (EN / FR / AR-romanized / AR-Levantine / PT-BR) as a
+live performance instrument made of three reusable components:
+
+1. **Camera** — the performer's (or viewer's) live video.
+2. **Words** — the poem line revealed as if live-transcribed, with an English
+   translation beneath the non-English lines.
+3. **Illustration** — a flat-geometric SVG composition (De Stijl primaries) that
+   morphs smoothly between keyframes, paced to speaking speed.
+
+Each of the five moments has its own **layout** (a grid arrangement of the three
+components). Layout changes are triggered live by a change in the performer's
+hand shape (MediaPipe Hand Landmarker). Illustration morphs are time-paced to the
+moment's spoken duration.
+
+The architecture is a generic **poem engine** (pure logic + DOM renderers) driven
+by a single `poem.json`, so future poems reuse the framework: new text, new
+keyframes, same machine.
+
+## Goals
+
+- A complete, playable five-moment poem sized to sit on an Instagram profile
+  (portrait, never overflowing its borders).
+- Buttery, alive morphing between geometric illustration states (no jarring cuts).
+- Hand-shape-driven layout transitions when a camera is available.
+- A deterministic, testable auto-play fallback when no camera (Instagram in-app
+  browser, denied permission, headless).
+- A reusable, data-driven engine for future poems.
+
+## Quality Gates
+
+These commands must pass for every user story (run from `mother-not-metaphor/`):
+
+- `npm run test:unit` — Node unit tests (pure engine + data shape)
+- `npm run lint:html` — html-validate on index.html
+- `npm run verify:purity` — no analytics/trackers; only the MediaPipe model is
+  allowed off-origin
+- `npm run test:e2e` — Playwright (mobile + desktop + reduced-motion)
+- `npm test` — runs all of the above in sequence
+
+## User Stories
+
+### US-001: Pure color engine (OKLab interpolation)
+
+**Description:** As the morph system, I want to interpolate two colors through
+OKLab so transitions between saturated primaries stay vivid.
+
+**Acceptance Criteria:**
+
+- [ ] `lerpColor(a, b, 0) === a` and `lerpColor(a, b, 1) === b`
+- [ ] Midpoint returns a valid `#rrggbb` string
+- [ ] blue→red midpoint has meaningful red AND blue channels (not gray)
+
+### US-002: Pure morph engine (rect interpolation + padding)
+
+**Description:** As the illustration, I want to interpolate between two frames of
+rectangles, handling differing cell counts.
+
+**Acceptance Criteria:**
+
+- [ ] `interpolateFrame(A, B, 0)` equals A; `(A, B, 1)` equals B geometry
+- [ ] Frames of differing length are padded to the max; extra cells are born/die
+      at a point (size 0, opacity 0)
+- [ ] `easeInOutCubic(0)=0`, `(1)=1`, `(0.5)=0.5`
+
+### US-003: Pure pacing engine
+
+**Description:** As the player, I want moment durations and keyframe schedules
+derived from text length and a speaking rate.
+
+**Acceptance Criteria:**
+
+- [ ] `momentDurationMs` clamps to `[min, max]`
+- [ ] `scheduleKeyframes(count, duration, morphMs)` returns `count` ascending
+      times within `[0, duration]`
+
+### US-004: Pure gesture engine
+
+**Description:** As the player, I want to derive a discrete hand signature from
+landmarks and detect stable changes.
+
+**Acceptance Criteria:**
+
+- [ ] `fingersUp` returns all-true for a synthetic open hand, all-false for a fist
+- [ ] `handSignature` is stable for the same pose, differs across poses
+- [ ] `stableSignature(history, n)` only reports a signature held ≥ n frames
+
+### US-005: Poem data + validation
+
+**Description:** As the author, I want the poem as data with a validated shape.
+
+**Acceptance Criteria:**
+
+- [ ] 5 moments with langs EN/FR/AR/AR-Levantine/PT-BR in order
+- [ ] Each moment names a layout in {L1..L5} (all five used, distinct)
+- [ ] Original text matches the canonical poem; non-English moments carry English
+- [ ] Every keyframe cell has numeric x,y,w,h and a fill in the palette
+
+### US-006: Illustration renderer (SVG)
+
+**Description:** As a viewer, I want the illustration to render and animate.
+
+**Acceptance Criteria:**
+
+- [ ] Renders an `<svg>` of `<rect>`s for the current moment
+- [ ] Animates between keyframes on a rAF loop using the morph engine
+- [ ] Respects `prefers-reduced-motion` (snaps instead of tweening)
+
+### US-007: Words renderer (typewriter transcription)
+
+**Description:** As a viewer, I want the line to type out like live captions with
+translation beneath non-English lines.
+
+**Acceptance Criteria:**
+
+- [ ] Original text reveals progressively over the moment's duration
+- [ ] A `[LANG]` tag shows; English translation shows for non-English moments
+- [ ] Original text is always rendered verbatim (no mistranscription)
+
+### US-008: Layout system + FLIP transitions
+
+**Description:** As a viewer, I want the three components to rearrange smoothly
+when the moment changes.
+
+**Acceptance Criteria:**
+
+- [ ] Five `data-layout` grid arrangements (L1..L5) place ME/WORDS/ILLUS
+- [ ] Component boxes animate to new positions via FLIP (snap under
+      reduced-motion)
+- [ ] Stage fits the viewport in portrait; no horizontal scroll/overflow
+
+### US-009: Camera + hand tracking (with fallback)
+
+**Description:** As a performer, I want my hand-shape changes to advance the poem;
+as an Instagram viewer with no camera, I want it to auto-play.
+
+**Acceptance Criteria:**
+
+- [ ] Requests camera; on grant, loads MediaPipe and tracks hands
+- [ ] A stable change in hand signature advances to the next moment
+- [ ] On denied/unavailable camera or MediaPipe failure, auto-plays on the pacing
+      timer
+- [ ] Exposes `window.MNM` (state/next/goTo) for tests and debugging
+
+### US-010: Landing integration
+
+**Description:** As a visitor, I want to find the piece in Featured.
+
+**Acceptance Criteria:**
+
+- [ ] A Featured card links to `/mother-not-metaphor/` with a thumbnail
+- [ ] Served statically; no vercel.json change required
+
+## Functional Requirements
+
+- FR-1: The piece must load and run with zero build step (vanilla ES modules).
+- FR-2: All five moments must be reachable; after the last, the piece holds (or
+  loops in auto mode).
+- FR-3: Non-English original text must render exactly as authored.
+- FR-4: The stage must never overflow the viewport (portrait, contained).
+- FR-5: The only permitted off-origin request is the MediaPipe Hand Landmarker
+  bundle + model; no analytics, beacons, or trackers.
+- FR-6: All animation must honor `prefers-reduced-motion`.
+
+## Non-Goals
+
+- Real speech-to-text (scripted typewriter only).
+- Recording or uploading the performer's video anywhere.
+- Multiple poems in this iteration (engine is reusable; only this poem ships).
+- Actual Arabic script (the poem is romanized; Latin glyphs only).
+
+## Technical Considerations
+
+- Pure modules (`color`, `morph`, `pacing`, `gestures`) are DOM-free for Node unit
+  tests; DOM modules are covered by Playwright.
+- MediaPipe `tasks-vision` is dynamically imported from a CDN; any failure must
+  degrade to auto-play.
+- Test acceleration via `?speed=` and forced fallback via `?mode=auto`.
+
+## Success Metrics
+
+- `npm test` green (unit + lint + purity + e2e) on mobile and desktop.
+- No console errors on load; no overflow at 390×844 (iPhone) and desktop.
+- Illustration morphs read as smooth (verified visually via screenshots).
+
+## Open Questions
+
+- Final thumbnail art and any brand-font layering (system grotesque ships now).
+- Whether auto mode should loop or end on a closing frame (currently holds).

--- a/mother-not-metaphor/tests/e2e/fragmentary.spec.mjs
+++ b/mother-not-metaphor/tests/e2e/fragmentary.spec.mjs
@@ -1,0 +1,241 @@
+// @ts-check
+/**
+ * tests/e2e/fragmentary.spec.mjs - deterministic, camera-free coverage of the
+ * gesture dwell + HUD behavior.
+ *
+ * Headless Chromium has no camera, so instead of hand tracking we drive
+ * window.MNM.feed(reading, now) - the SAME entry point the real tracker calls -
+ * with fake monotonic timestamps. The control's stableFrames + dwell + reset
+ * logic runs for real; only the clock is synthetic.
+ *
+ * A "reading" is { present:true, up:[bool x5], extensions:[0..1 x5] } (finger
+ * order thumb,index,middle,ring,pinky) or { present:false }. To fire, a bound
+ * pose must (a) follow a RESET - a neutral (unbound) pose or an absent hand -
+ * and (b) be HELD for dwellMs. The shipped bindings are open hand -> next and
+ * peace sign -> back; a fist/relaxed hand is unbound (a neutral / reset).
+ */
+
+import { test, expect } from "@playwright/test";
+
+const AUTO = "/?mode=auto&speed=12";
+
+// Poses (thumb, index, middle, ring, pinky).
+const OPEN = [true, true, true, true, true]; // -> next
+const PEACE = [false, true, true, false, false]; // -> back
+const FIST = [false, false, false, false, false]; // neutral (reset)
+
+async function ready(page) {
+  await page.goto(AUTO);
+  await page.waitForFunction(
+    () => !!window.MNM && typeof window.MNM.feed === "function",
+  );
+}
+
+/**
+ * Install an in-page driver on window.__fx with a single monotonic fake clock.
+ *   hold(up, ms)  - stabilize then hold `up` across `ms` of fake time
+ *   reset()       - feed a neutral (fist) long enough to arm + set the reset flag
+ *   drop(n)       - feed present:false n frames (hand absent, also resets)
+ *   dwell()       - window.MNM.config.dwellMs
+ */
+async function installDriver(page) {
+  await page.evaluate(() => {
+    const w = /** @type {any} */ (window);
+    const M = w.MNM;
+    const stableFrames = () => M.config.stableFrames || 4;
+    const ext = (up) => up.map((b) => (b ? 1 : 0));
+    let t = 100000;
+
+    const feedOnce = (up) =>
+      M.feed(
+        up == null
+          ? { present: false, up: null, extensions: [0, 0, 0, 0, 0] }
+          : { present: true, up: up.slice(), extensions: ext(up) },
+        t,
+      );
+
+    w.__fx = {
+      dwell: () => M.config.dwellMs,
+      now: () => t,
+      hold(up, ms, step = 40) {
+        const start = t;
+        let last = null;
+        for (let i = 0; i < stableFrames() + 1; i++) last = feedOnce(up);
+        while (t - start < ms) {
+          t += step;
+          last = feedOnce(up);
+        }
+        return last;
+      },
+      // A neutral (unbound) pose: arms if needed AND sets the reset flag.
+      reset(frames = stableFrames() + 3) {
+        let last = null;
+        for (let i = 0; i < frames; i++) {
+          last = feedOnce([false, false, false, false, false]);
+          t += 16;
+        }
+        return last;
+      },
+      drop(n = 6) {
+        let last = null;
+        for (let i = 0; i < n; i++) {
+          last = feedOnce(null);
+          t += 16;
+        }
+        return last;
+      },
+    };
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await ready(page);
+  await installDriver(page);
+});
+
+test("arming: a first stable open hand (no reset) does not advance", async ({
+  page,
+}) => {
+  const index = await page.evaluate(
+    ({ OPEN }) => {
+      const w = /** @type {any} */ (window);
+      w.MNM.goTo(0);
+      w.__fx.hold(OPEN, 3000); // held open the whole time, never reset
+      return w.MNM.state().index;
+    },
+    { OPEN },
+  );
+  expect(index).toBe(0);
+});
+
+test("a relaxed/neutral hand never advances", async ({ page }) => {
+  const index = await page.evaluate(() => {
+    const w = /** @type {any} */ (window);
+    w.MNM.goTo(0);
+    w.__fx.hold([false, false, false, false, false], 4000); // fist is unbound
+    return w.MNM.state().index;
+  });
+  expect(index).toBe(0);
+});
+
+test("open hand advances after a reset + full dwell, not before", async ({
+  page,
+}) => {
+  const r = await page.evaluate(
+    ({ OPEN }) => {
+      const w = /** @type {any} */ (window);
+      const fx = w.__fx;
+      w.MNM.goTo(0);
+      fx.reset(); // relax (neutral) -> enables firing
+      fx.hold(OPEN, Math.floor(fx.dwell() * 0.5));
+      const mid = w.MNM.state().index;
+      fx.hold(OPEN, fx.dwell()); // cumulative hold now exceeds the dwell
+      return { mid, after: w.MNM.state().index };
+    },
+    { OPEN },
+  );
+  expect(r.mid, "must not fire before the dwell").toBe(0);
+  expect(r.after, "fires once held past the dwell").toBe(1);
+});
+
+test("HUD reflects the fingers and fills the meter mid-hold", async ({
+  page,
+}) => {
+  const hud = await page.evaluate(
+    ({ PEACE }) => {
+      const w = /** @type {any} */ (window);
+      const fx = w.__fx;
+      document.getElementById("stage").setAttribute("data-hud", "on");
+      w.MNM.goTo(0);
+      fx.reset(); // so the held peace pose actually accrues dwell
+      fx.hold(PEACE, Math.floor(fx.dwell() * 0.4)); // partway
+
+      const bars = [...document.querySelectorAll("#hud-panel .fx-bar")];
+      const fillH = (i) =>
+        parseFloat(
+          (bars[i].querySelector(".fx-bar__fill").style.height || "").trim(),
+        ) || 0;
+      const meter = document.querySelector("#hud-panel .fx-meter__fill");
+      return {
+        barCount: bars.length,
+        indexUp: bars[1].classList.contains("is-up"),
+        middleUp: bars[2].classList.contains("is-up"),
+        thumbUp: bars[0].classList.contains("is-up"),
+        indexFill: fillH(1),
+        ringFill: fillH(3),
+        pinkyFill: fillH(4),
+        meterW: parseFloat((meter.style.width || "").trim()) || 0,
+      };
+    },
+    { PEACE },
+  );
+
+  expect(hud.barCount).toBe(5);
+  expect(hud.indexUp).toBe(true);
+  expect(hud.middleUp).toBe(true);
+  expect(hud.thumbUp).toBe(false);
+  expect(hud.indexFill).toBeGreaterThan(hud.ringFill);
+  expect(hud.ringFill).toBe(0);
+  expect(hud.pinkyFill).toBe(0);
+  expect(hud.meterW).toBeGreaterThan(0);
+  expect(hud.meterW).toBeLessThan(100);
+});
+
+test("a neutral pose (not a full drop) resets between advances", async ({
+  page,
+}) => {
+  const r = await page.evaluate(
+    ({ OPEN }) => {
+      const w = /** @type {any} */ (window);
+      const fx = w.__fx;
+      w.MNM.goTo(0);
+      fx.reset();
+      fx.hold(OPEN, fx.dwell() + 300);
+      const first = w.MNM.state().index;
+      fx.reset(); // relax in frame, no full drop
+      fx.hold(OPEN, fx.dwell() + 300);
+      return { first, second: w.MNM.state().index };
+    },
+    { OPEN },
+  );
+  expect(r.first).toBe(1);
+  expect(r.second).toBe(2);
+});
+
+test("a peace sign fires the back binding (steps to the previous moment)", async ({
+  page,
+}) => {
+  const index = await page.evaluate(
+    ({ PEACE }) => {
+      const w = /** @type {any} */ (window);
+      const fx = w.__fx;
+      w.MNM.goTo(2);
+      fx.reset();
+      fx.hold(PEACE, fx.dwell() + 300);
+      return w.MNM.state().index;
+    },
+    { PEACE },
+  );
+  expect(index).toBe(1);
+});
+
+test("the shipped default config is loaded (dwell ~1500, next + prev bindings)", async ({
+  page,
+}) => {
+  const cfg = await page.evaluate(() => {
+    const c = /** @type {any} */ (window).MNM.config;
+    return {
+      dwellMs: c.dwellMs,
+      hasNext: (c.bindings || []).some(
+        (b) => b.action && b.action.type === "next",
+      ),
+      hasPrev: (c.bindings || []).some(
+        (b) => b.action && b.action.type === "prev",
+      ),
+    };
+  });
+  expect(cfg.dwellMs).toBeGreaterThanOrEqual(1000);
+  expect(cfg.dwellMs).toBeLessThanOrEqual(2500);
+  expect(cfg.hasNext).toBe(true);
+  expect(cfg.hasPrev).toBe(true);
+});

--- a/mother-not-metaphor/tests/e2e/piece.spec.mjs
+++ b/mother-not-metaphor/tests/e2e/piece.spec.mjs
@@ -1,0 +1,146 @@
+// @ts-check
+import { test, expect } from "@playwright/test";
+
+const AUTO = "/?mode=auto&speed=12";
+
+/** Wait until the engine has booted and exposed its debug API. */
+async function ready(page) {
+  await page.waitForFunction(
+    () => !!window.MNM && window.MNM.state().index >= 0,
+  );
+}
+
+test("boots with no console errors and opens on the first moment (L1/EN)", async ({
+  page,
+}) => {
+  const errors = [];
+  page.on("console", (m) => m.type() === "error" && errors.push(m.text()));
+  page.on("pageerror", (e) => errors.push(String(e)));
+
+  await page.goto(AUTO);
+  await ready(page);
+
+  const stage = page.locator("#stage");
+  await expect(stage).toHaveAttribute("data-moment", "en");
+  await expect(stage).toHaveAttribute("data-layout", "L1");
+  await expect
+    .poll(() => page.locator("#words-caption").textContent())
+    .toContain("ocean");
+
+  expect(errors, errors.join("\n")).toEqual([]);
+});
+
+test("auto-plays through all five moments to the end", async ({ page }) => {
+  await page.goto(AUTO);
+  await ready(page);
+  await expect
+    .poll(() => page.evaluate(() => window.MNM.state().index), {
+      timeout: 15000,
+    })
+    .toBe(4);
+  await expect(page.locator("#stage")).toHaveAttribute("data-moment", "pt-br");
+});
+
+test("each moment carries its own layout and renders illustration rects", async ({
+  page,
+}) => {
+  await page.goto("/?mode=auto&speed=0.6"); // slow so a jumped-to moment holds
+  await ready(page);
+
+  const expected = [
+    ["en", "L1"],
+    ["fr", "L2"],
+    ["ar", "L3"],
+    ["ar-lev", "L4"],
+    ["pt-br", "L5"],
+  ];
+
+  for (let i = 0; i < expected.length; i++) {
+    const layout = await page.evaluate((idx) => {
+      window.MNM.goTo(idx);
+      return document.getElementById("stage").getAttribute("data-layout");
+    }, i);
+    expect(layout, `moment ${expected[i][0]}`).toBe(expected[i][1]);
+    await expect(page.locator("#stage")).toHaveAttribute(
+      "data-moment",
+      expected[i][0],
+    );
+
+    // visible rects accumulate as the morph runs
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const rects = [...document.querySelectorAll("#illus-svg rect")];
+          return rects.filter((r) => {
+            const w = parseFloat(r.getAttribute("width") || "0");
+            const o = parseFloat(r.getAttribute("opacity") || "0");
+            return w > 0 && o > 0;
+          }).length;
+        }),
+      )
+      .toBeGreaterThan(0);
+  }
+});
+
+test("non-English moments show the original verbatim and an English translation", async ({
+  page,
+}) => {
+  await page.goto("/?mode=auto&speed=0.6");
+  await ready(page);
+
+  // FR
+  await page.evaluate(() => window.MNM.goTo(1));
+  await expect
+    .poll(() => page.locator("#words-caption").textContent())
+    .toContain("Ma mère");
+  await expect
+    .poll(() => page.locator("#words-translation").textContent())
+    .toContain("knead");
+  await expect(page.locator("#words-tag")).toHaveText("[FR]");
+
+  // AR (romanized)
+  await page.evaluate(() => window.MNM.goTo(2));
+  await expect
+    .poll(() => page.locator("#words-caption").textContent())
+    .toContain("Oummi dam3i");
+  await expect(page.locator("#words-tag")).toHaveText("[AR]");
+});
+
+test("the stage fits the viewport with no horizontal overflow", async ({
+  page,
+}) => {
+  await page.goto(AUTO);
+  await ready(page);
+  const overflow = await page.evaluate(() => {
+    const doc = document.documentElement;
+    const stage = document.getElementById("stage").getBoundingClientRect();
+    return {
+      docOverflow: doc.scrollWidth - doc.clientWidth,
+      stageRight: stage.right,
+      stageBottom: stage.bottom,
+      vw: window.innerWidth,
+      vh: window.innerHeight,
+    };
+  });
+  expect(overflow.docOverflow).toBeLessThanOrEqual(1);
+  expect(overflow.stageRight).toBeLessThanOrEqual(overflow.vw + 1);
+  expect(overflow.stageBottom).toBeLessThanOrEqual(overflow.vh + 1);
+});
+
+test("the start gate falls back to auto-play when no camera is available", async ({
+  page,
+}) => {
+  await page.goto("/?speed=12"); // no mode -> intro gate shown
+  await expect(page.locator("#intro")).toBeVisible();
+  await page.locator("#start").click();
+  await expect(page.locator("#intro")).toBeHidden();
+  // camera is denied/absent in headless -> player should still begin
+  await expect
+    .poll(
+      () => page.evaluate(() => (window.MNM ? window.MNM.state().index : -1)),
+      {
+        timeout: 15000,
+      },
+    )
+    .toBeGreaterThanOrEqual(0);
+});

--- a/mother-not-metaphor/tests/unit/color.test.mjs
+++ b/mother-not-metaphor/tests/unit/color.test.mjs
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  lerpColor,
+  normalizeHex,
+  hexToRgb,
+  rgbToHex,
+} from "../../src/color.js";
+
+test("hex round-trips", () => {
+  assert.equal(rgbToHex(...hexToRgb("#2138de")), "#2138de");
+  assert.equal(normalizeHex("#FFF"), "#ffffff");
+  assert.equal(normalizeHex("#000000"), "#000000");
+});
+
+test("lerp endpoints are exact", () => {
+  assert.equal(lerpColor("#2138de", "#e8381f", 0), "#2138de");
+  assert.equal(lerpColor("#2138de", "#e8381f", 1), "#e8381f");
+});
+
+test("midpoint is a valid 6-digit hex", () => {
+  const mid = lerpColor("#2138de", "#e8381f", 0.5);
+  assert.match(mid, /^#[0-9a-f]{6}$/);
+});
+
+test("blue->red midpoint stays vivid (not grey mud)", () => {
+  // Through OKLab, blue->red passes through a saturated purple/magenta: both the
+  // red and blue channels should be substantial, and not all three near-equal.
+  const [r, g, b] = hexToRgb(lerpColor("#2138de", "#e8381f", 0.5));
+  assert.ok(r > 90, `expected lively red channel, got ${r}`);
+  assert.ok(b > 70, `expected lively blue channel, got ${b}`);
+  const maxC = Math.max(r, g, b);
+  const minC = Math.min(r, g, b);
+  assert.ok(maxC - minC > 60, "midpoint should be chromatic, not grey");
+});
+
+test("black->white midpoint is a mid grey", () => {
+  const [r, g, b] = hexToRgb(lerpColor("#000000", "#ffffff", 0.5));
+  assert.ok(Math.abs(r - g) < 3 && Math.abs(g - b) < 3, "grey: channels equal");
+  // OKLab L is perceptual: the black/white midpoint sits below sRGB 128 (~99).
+  assert.ok(r > 80 && r < 170, `mid grey, got ${r}`);
+});

--- a/mother-not-metaphor/tests/unit/config.test.mjs
+++ b/mother-not-metaphor/tests/unit/config.test.mjs
@@ -1,0 +1,93 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  validateConfig,
+  mergeConfig,
+  normalizeBinding,
+  normalizeAction,
+  normalizeFingers,
+  loadStored,
+  saveStored,
+} from "../../src/fragmentary/config.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+test("the shipped default config is valid and round-trips through validate", () => {
+  const raw = JSON.parse(
+    fs.readFileSync(
+      path.resolve(__dirname, "../../data/gestures.json"),
+      "utf8",
+    ),
+  );
+  const cfg = validateConfig(raw);
+  assert.ok(cfg.dwellMs >= 1000 && cfg.dwellMs <= 2000, "default dwell ~1-2s");
+  assert.ok(cfg.bindings.length >= 1);
+  assert.equal(cfg.bindings[0].action.type, "next");
+  // idempotent
+  assert.deepEqual(validateConfig(cfg), cfg);
+});
+
+test("validateConfig clamps and fills defaults, never throws", () => {
+  assert.deepEqual(validateConfig(null), {
+    dwellMs: 1500,
+    stableFrames: 4,
+    showHud: true,
+    bindings: [],
+  });
+  assert.equal(validateConfig({ dwellMs: 50 }).dwellMs, 300); // clamp low
+  assert.equal(validateConfig({ dwellMs: 99999 }).dwellMs, 6000); // clamp high
+  assert.equal(validateConfig({ stableFrames: 2.7 }).stableFrames, 3); // round
+  assert.equal(validateConfig({ showHud: false }).showHud, false);
+});
+
+test("normalizeAction / normalizeFingers coerce junk", () => {
+  assert.deepEqual(normalizeAction({ type: "bogus" }), { type: "next" });
+  assert.deepEqual(normalizeAction({ type: "goto", index: "3" }), {
+    type: "goto",
+    index: 3,
+  });
+  assert.deepEqual(normalizeFingers({ index: "up", ring: "sideways" }), {
+    thumb: "any",
+    index: "up",
+    middle: "any",
+    ring: "any",
+    pinky: "any",
+  });
+});
+
+test("normalizeBinding fills id/label/action/fingers", () => {
+  const b = normalizeBinding({ fingers: { index: "up" } }, 2);
+  assert.equal(b.id, "b2");
+  assert.equal(b.action.type, "next");
+  assert.equal(b.fingers.index, "up");
+  assert.equal(normalizeBinding(null), null);
+});
+
+test("mergeConfig layers an override over defaults", () => {
+  const defaults = {
+    dwellMs: 1500,
+    stableFrames: 4,
+    bindings: [{ action: { type: "next" }, fingers: {} }],
+  };
+  const merged = mergeConfig(defaults, { dwellMs: 900 });
+  assert.equal(merged.dwellMs, 900);
+  assert.equal(
+    merged.bindings.length,
+    1,
+    "keeps default bindings when override omits them",
+  );
+  const replaced = mergeConfig(defaults, { bindings: [] });
+  assert.equal(
+    replaced.bindings.length,
+    0,
+    "override bindings replace defaults",
+  );
+});
+
+test("storage helpers no-op safely without localStorage (Node)", () => {
+  assert.equal(loadStored("nope"), null);
+  assert.equal(saveStored({ dwellMs: 1000 }, "nope"), false);
+});

--- a/mother-not-metaphor/tests/unit/control.test.mjs
+++ b/mother-not-metaphor/tests/unit/control.test.mjs
@@ -1,0 +1,233 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  matchBinding,
+  bindingSpecificity,
+  pickBinding,
+  patternKey,
+  createGestureControl,
+} from "../../src/fragmentary/control.js";
+
+const OPEN = [true, true, true, true, true];
+const PEACE = [false, true, true, false, false];
+const FIST = [false, false, false, false, false];
+const POINT = [false, true, false, false, false];
+
+// Bound poses used by the state-machine tests (open -> next, peace -> prev).
+// FIST / POINT match neither, so they are NEUTRAL (they provide the reset).
+const NEXT = {
+  id: "next",
+  action: { type: "next" },
+  fingers: { thumb: "up", index: "up", middle: "up", ring: "up", pinky: "up" },
+};
+const PREV = {
+  id: "back",
+  action: { type: "prev" },
+  fingers: {
+    thumb: "down",
+    index: "up",
+    middle: "up",
+    ring: "down",
+    pinky: "down",
+  },
+};
+const BINDINGS = [NEXT, PREV];
+
+// pure-matching fixtures
+const ANY = { id: "any", action: { type: "next" }, fingers: {} };
+const FISTB = {
+  id: "fistb",
+  action: { type: "prev" },
+  fingers: {
+    thumb: "down",
+    index: "down",
+    middle: "down",
+    ring: "down",
+    pinky: "down",
+  },
+};
+
+test("patternKey encodes finger bits", () => {
+  assert.equal(patternKey(OPEN), "11111");
+  assert.equal(patternKey(POINT), "01000");
+});
+
+test("matchBinding / specificity / pickBinding", () => {
+  assert.equal(matchBinding(OPEN, ANY), true);
+  assert.equal(matchBinding(FIST, FISTB), true);
+  assert.equal(matchBinding(OPEN, FISTB), false);
+  assert.equal(bindingSpecificity(ANY), 0);
+  assert.equal(bindingSpecificity(FISTB), 5);
+  assert.equal(pickBinding(FIST, [ANY, FISTB]).id, "fistb"); // most specific wins
+  assert.equal(pickBinding(OPEN, [ANY, FISTB]).id, "any");
+});
+
+// Feed `up` for enough stable frames, then keep holding until `untilMs`.
+// Returns the firing frame if any (firing is a single-frame event), else last.
+function hold(ctrl, up, startMs, untilMs, stableFrames = 4, step = 16) {
+  let last;
+  let fired = null;
+  const feed = (t) => {
+    last = ctrl.update(up, t);
+    if (last.firing) fired = last;
+  };
+  for (let i = 0; i < stableFrames; i++) feed(startMs);
+  for (let t = startMs; t <= untilMs; t += step) feed(t);
+  return fired || last;
+}
+
+// Feed a neutral (unbound) pose or absence to satisfy the reset requirement.
+function resetVia(ctrl, up, atMs, frames = 5) {
+  let last;
+  for (let i = 0; i < frames; i++) last = ctrl.update(up, atMs);
+  return last;
+}
+
+test("a hand held in one bound pose from the start never fires (arm-only)", () => {
+  const ctrl = createGestureControl({
+    dwellMs: 1000,
+    stableFrames: 4,
+    bindings: BINDINGS,
+  });
+  const r = hold(ctrl, OPEN, 0, 5000); // open the whole time, never reset
+  assert.equal(r.firing, false, "no reset ever occurred, so it must not fire");
+  assert.equal(r.armed, true);
+});
+
+test("a hand resting in a NEUTRAL pose never fires", () => {
+  const ctrl = createGestureControl({
+    dwellMs: 800,
+    stableFrames: 4,
+    bindings: BINDINGS,
+  });
+  const r = hold(ctrl, FIST, 0, 5000); // fist is unbound here -> neutral
+  assert.equal(r.firing, false);
+});
+
+test("a bound pose fires only after a reset AND a full dwell", () => {
+  const ctrl = createGestureControl({
+    dwellMs: 1000,
+    stableFrames: 4,
+    bindings: BINDINGS,
+  });
+  hold(ctrl, OPEN, 0, 100); // arm on open (no reset yet)
+  // holding open with no reset must not fire
+  assert.equal(
+    hold(ctrl, OPEN, 120, 1400).firing,
+    false,
+    "no reset -> no fire",
+  );
+  // relax to a neutral pose -> reset
+  resetVia(ctrl, FIST, 1500);
+  // now hold open: not before the dwell...
+  ctrl.update(OPEN, 1600);
+  ctrl.update(OPEN, 1616);
+  ctrl.update(OPEN, 1632);
+  let r = ctrl.update(OPEN, 1648); // stable, candSince ~1648
+  assert.ok(r.progress < 0.2 && !r.firing, `just started ${r.progress}`);
+  r = ctrl.update(OPEN, 1648 + 500);
+  assert.ok(
+    r.progress > 0.3 && r.progress < 0.7 && !r.firing,
+    `mid ${r.progress}`,
+  );
+  r = ctrl.update(OPEN, 1648 + 1000);
+  assert.equal(r.firing, true, "fires after the full dwell");
+  assert.deepEqual(r.action, { type: "next" });
+});
+
+test("a neutral pose (not a full drop) provides the reset between fires", () => {
+  const ctrl = createGestureControl({
+    dwellMs: 500,
+    stableFrames: 4,
+    bindings: BINDINGS,
+  });
+  resetVia(ctrl, FIST, 0); // reset (also arms)
+  assert.equal(hold(ctrl, OPEN, 50, 800).firing, true, "first open fires");
+  resetVia(ctrl, FIST, 900); // neutral reset, hand stays in frame
+  assert.equal(
+    hold(ctrl, OPEN, 1000, 1800).firing,
+    true,
+    "second open fires after a neutral",
+  );
+});
+
+test("dropping the hand (absence) also resets", () => {
+  const ctrl = createGestureControl({
+    dwellMs: 500,
+    stableFrames: 4,
+    bindings: BINDINGS,
+  });
+  resetVia(ctrl, FIST, 0);
+  assert.equal(hold(ctrl, OPEN, 50, 800).firing, true);
+  resetVia(ctrl, null, 900); // hand gone
+  assert.equal(
+    hold(ctrl, OPEN, 1000, 1800).firing,
+    true,
+    "same pose fires again after a drop",
+  );
+});
+
+test("peace fires prev, open fires next (per-binding action)", () => {
+  const ctrl = createGestureControl({
+    dwellMs: 400,
+    stableFrames: 4,
+    bindings: BINDINGS,
+  });
+  resetVia(ctrl, FIST, 0);
+  assert.deepEqual(hold(ctrl, OPEN, 50, 700).action, { type: "next" });
+  resetVia(ctrl, FIST, 800);
+  assert.deepEqual(hold(ctrl, PEACE, 900, 1600).action, { type: "prev" });
+});
+
+test("holding the just-fired pose does not re-fire until reset", () => {
+  const ctrl = createGestureControl({
+    dwellMs: 400,
+    stableFrames: 4,
+    bindings: BINDINGS,
+  });
+  resetVia(ctrl, FIST, 0);
+  assert.equal(hold(ctrl, OPEN, 50, 700).firing, true);
+  const held = hold(ctrl, OPEN, 800, 3000); // keep holding open, no reset
+  assert.equal(held.firing, false, "no re-fire while held");
+});
+
+test("jitter (never stable) never fires", () => {
+  const ctrl = createGestureControl({
+    dwellMs: 200,
+    stableFrames: 4,
+    bindings: [ANY],
+  });
+  let r;
+  for (let t = 0; t < 2000; t += 16)
+    r = ctrl.update(t % 32 === 0 ? OPEN : POINT, t);
+  assert.equal(r.firing, false);
+});
+
+test("guards: non-finite now and zero dwell never produce NaN progress", () => {
+  const ctrl = createGestureControl({
+    dwellMs: 0,
+    stableFrames: 2,
+    bindings: [ANY],
+  });
+  assert.ok(ctrl.config.dwellMs > 0, "zero dwell is clamped to positive");
+  resetVia(ctrl, null, 0, 3);
+  ctrl.update(OPEN, 0);
+  const r = ctrl.update(OPEN, Number.NaN);
+  assert.equal(Number.isFinite(r.progress), true);
+  assert.ok(r.progress >= 0 && r.progress <= 1);
+});
+
+test("setConfig swaps dwell live", () => {
+  const ctrl = createGestureControl({
+    dwellMs: 5000,
+    stableFrames: 4,
+    bindings: BINDINGS,
+  });
+  ctrl.setConfig({ dwellMs: 300 });
+  resetVia(ctrl, FIST, 0);
+  assert.equal(
+    hold(ctrl, OPEN, 50, 500).firing,
+    true,
+    "shorter dwell now fires",
+  );
+});

--- a/mother-not-metaphor/tests/unit/gestures.test.mjs
+++ b/mother-not-metaphor/tests/unit/gestures.test.mjs
@@ -1,0 +1,98 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  fingersUp,
+  orientation,
+  handSignature,
+  stableSignature,
+  signatureChanged,
+} from "../../src/gestures.js";
+
+// Build a 21-point landmark array, then override the indices the engine reads.
+function hand(overrides) {
+  const lm = Array.from({ length: 21 }, () => ({ x: 0.5, y: 0.5, z: 0 }));
+  for (const [i, p] of Object.entries(overrides)) lm[i] = { z: 0, ...p };
+  return lm;
+}
+
+// Open right hand pointing up: tips well above pips, thumb out to the left.
+const OPEN = hand({
+  0: { x: 0.5, y: 0.9 }, // wrist
+  4: { x: 0.3, y: 0.55 }, // thumb tip (left of index mcp)
+  5: { x: 0.45, y: 0.6 }, // index mcp (ref)
+  6: { x: 0.45, y: 0.45 }, // index pip
+  8: { x: 0.45, y: 0.2 }, // index tip
+  9: { x: 0.5, y: 0.55 }, // middle mcp
+  10: { x: 0.5, y: 0.45 },
+  12: { x: 0.5, y: 0.15 },
+  14: { x: 0.55, y: 0.45 },
+  16: { x: 0.55, y: 0.2 },
+  18: { x: 0.6, y: 0.45 },
+  20: { x: 0.6, y: 0.25 },
+});
+
+// Fist: tips below pips, thumb tucked across.
+const FIST = hand({
+  0: { x: 0.5, y: 0.9 },
+  4: { x: 0.44, y: 0.55 },
+  5: { x: 0.45, y: 0.6 },
+  6: { x: 0.45, y: 0.45 },
+  8: { x: 0.45, y: 0.55 },
+  9: { x: 0.5, y: 0.55 },
+  10: { x: 0.5, y: 0.45 },
+  12: { x: 0.5, y: 0.55 },
+  14: { x: 0.55, y: 0.45 },
+  16: { x: 0.55, y: 0.55 },
+  18: { x: 0.6, y: 0.45 },
+  20: { x: 0.6, y: 0.55 },
+});
+
+test("fingersUp: open hand is all extended", () => {
+  assert.deepEqual(fingersUp(OPEN, "Right"), [true, true, true, true, true]);
+});
+
+test("fingersUp: fist is none extended", () => {
+  assert.deepEqual(fingersUp(FIST, "Right"), [
+    false,
+    false,
+    false,
+    false,
+    false,
+  ]);
+});
+
+test("fingersUp: bad input is safe", () => {
+  assert.deepEqual(fingersUp(null), [false, false, false, false, false]);
+  assert.deepEqual(fingersUp([{ x: 0, y: 0 }]), [
+    false,
+    false,
+    false,
+    false,
+    false,
+  ]);
+});
+
+test("orientation reads pointing direction", () => {
+  assert.equal(orientation(OPEN), "up");
+});
+
+test("handSignature differs across poses, stable within a pose", () => {
+  const sOpen = handSignature(OPEN, "Right");
+  const sFist = handSignature(FIST, "Right");
+  assert.notEqual(sOpen, sFist);
+  assert.equal(handSignature(OPEN, "Right"), sOpen);
+  assert.match(sOpen, /^11111:/);
+  assert.match(sFist, /^00000:/);
+});
+
+test("stableSignature requires n identical recent frames", () => {
+  assert.equal(stableSignature(["a", "a", "b"], 3), null);
+  assert.equal(stableSignature(["x", "a", "a", "a"], 3), "a");
+  assert.equal(stableSignature(["a", "a"], 3), null); // too short
+});
+
+test("signatureChanged needs two distinct non-null signatures", () => {
+  assert.equal(signatureChanged("a", "b"), true);
+  assert.equal(signatureChanged("a", "a"), false);
+  assert.equal(signatureChanged(null, "b"), false);
+});

--- a/mother-not-metaphor/tests/unit/gestures.test.mjs
+++ b/mother-not-metaphor/tests/unit/gestures.test.mjs
@@ -2,11 +2,13 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   fingersUp,
+  fingerExtensions,
+  handReading,
   orientation,
   handSignature,
   stableSignature,
   signatureChanged,
-} from "../../src/gestures.js";
+} from "../../src/fragmentary/gestures.js";
 
 // Build a 21-point landmark array, then override the indices the engine reads.
 function hand(overrides) {
@@ -95,4 +97,41 @@ test("signatureChanged needs two distinct non-null signatures", () => {
   assert.equal(signatureChanged("a", "b"), true);
   assert.equal(signatureChanged("a", "a"), false);
   assert.equal(signatureChanged(null, "b"), false);
+});
+
+test("fingerExtensions: open hand reads more extended than a fist", () => {
+  const open = fingerExtensions(OPEN);
+  const fist = fingerExtensions(FIST);
+  assert.equal(open.length, 5);
+  const mean = (a) => a.reduce((s, v) => s + v, 0) / a.length;
+  assert.ok(
+    mean(open) > mean(fist) + 0.2,
+    `open ${mean(open)} vs fist ${mean(fist)}`,
+  );
+  // every non-thumb finger reads clearly more extended open than in a fist
+  for (let i = 1; i < 5; i++) {
+    assert.ok(
+      open[i] > fist[i] + 0.15,
+      `finger ${i}: open ${open[i]} vs fist ${fist[i]}`,
+    );
+  }
+  for (const v of open.concat(fist)) assert.ok(v >= 0 && v <= 1);
+});
+
+test("fingerExtensions: bad input is safe zeros", () => {
+  assert.deepEqual(fingerExtensions(null), [0, 0, 0, 0, 0]);
+  assert.deepEqual(fingerExtensions([{ x: 0, y: 0 }]), [0, 0, 0, 0, 0]);
+});
+
+test("handReading bundles present/up/extensions/signature", () => {
+  const r = handReading(OPEN, "Right");
+  assert.equal(r.present, true);
+  assert.deepEqual(r.up, [true, true, true, true, true]);
+  assert.equal(r.extensions.length, 5);
+  assert.match(r.signature, /^11111:/);
+
+  const none = handReading(null);
+  assert.equal(none.present, false);
+  assert.equal(none.signature, "none");
+  assert.deepEqual(none.up, [false, false, false, false, false]);
 });

--- a/mother-not-metaphor/tests/unit/morph.test.mjs
+++ b/mother-not-metaphor/tests/unit/morph.test.mjs
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  easeInOutCubic,
+  ghostOf,
+  padPair,
+  lerpCell,
+  interpolateFrame,
+} from "../../src/morph.js";
+
+const A = [{ x: 10, y: 10, w: 20, h: 20, fill: "#2138de", o: 1 }];
+const B = [
+  { x: 50, y: 50, w: 10, h: 10, fill: "#e8381f", o: 1 },
+  { x: 70, y: 70, w: 8, h: 8, fill: "#1e854a", o: 1 },
+];
+
+test("easeInOutCubic anchors", () => {
+  assert.equal(easeInOutCubic(0), 0);
+  assert.equal(easeInOutCubic(1), 1);
+  assert.equal(easeInOutCubic(0.5), 0.5);
+  assert.ok(easeInOutCubic(0.25) < 0.25, "ease-in accelerates from rest");
+});
+
+test("ghost collapses to a point at the target center, transparent", () => {
+  const g = ghostOf(B[1]);
+  assert.equal(g.w, 0);
+  assert.equal(g.h, 0);
+  assert.equal(g.o, 0);
+  assert.equal(g.x, 74); // 70 + 8/2
+  assert.equal(g.y, 74);
+  assert.equal(g.fill, "#1e854a");
+});
+
+test("padPair lengthens the shorter frame with ghosts", () => {
+  const [a, b] = padPair(A, B);
+  assert.equal(a.length, 2);
+  assert.equal(b.length, 2);
+  assert.equal(a[1].o, 0, "the born cell starts transparent");
+});
+
+test("lerpCell interpolates geometry linearly", () => {
+  const c = lerpCell(A[0], B[0], 0.5);
+  assert.equal(c.x, 30);
+  assert.equal(c.y, 30);
+  assert.equal(c.w, 15);
+  assert.equal(c.h, 15);
+});
+
+test("interpolateFrame endpoints reproduce inputs (padded)", () => {
+  const at0 = interpolateFrame(A, B, 0);
+  assert.equal(at0[0].x, 10);
+  assert.equal(at0[0].w, 20);
+  // the padded ghost sits at B[1]'s center with zero size
+  assert.equal(at0[1].w, 0);
+  assert.equal(at0[1].o, 0);
+
+  const at1 = interpolateFrame(A, B, 1);
+  assert.equal(at1[0].x, 50);
+  assert.equal(at1[1].x, 70);
+  assert.equal(at1[1].w, 8);
+  assert.equal(at1[1].o, 1);
+});
+
+test("interpolateFrame midpoint grows the born cell partway", () => {
+  const mid = interpolateFrame(A, B, 0.5);
+  assert.ok(mid[1].w > 0 && mid[1].w < 8, "born cell is mid-growth");
+  assert.ok(mid[1].o > 0 && mid[1].o < 1, "born cell is fading in");
+});

--- a/mother-not-metaphor/tests/unit/pacing.test.mjs
+++ b/mother-not-metaphor/tests/unit/pacing.test.mjs
@@ -1,0 +1,39 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_PACING,
+  momentDurationMs,
+  scheduleKeyframes,
+} from "../../src/pacing.js";
+
+test("momentDurationMs clamps to the configured range", () => {
+  assert.equal(momentDurationMs(""), DEFAULT_PACING.minMomentMs);
+  assert.equal(momentDurationMs("x".repeat(5000)), DEFAULT_PACING.maxMomentMs);
+});
+
+test("momentDurationMs scales with text length in range", () => {
+  const short = momentDurationMs("x".repeat(120));
+  const long = momentDurationMs("x".repeat(180));
+  assert.ok(long > short, "longer line takes longer");
+  assert.ok(
+    short >= DEFAULT_PACING.minMomentMs && long <= DEFAULT_PACING.maxMomentMs,
+  );
+});
+
+test("scheduleKeyframes returns count ascending starts within duration", () => {
+  const dur = 9000;
+  const sched = scheduleKeyframes(4, dur);
+  assert.equal(sched.length, 4);
+  assert.equal(sched[0].start, 0);
+  for (let i = 1; i < sched.length; i++) {
+    assert.ok(sched[i].start > sched[i - 1].start, "strictly ascending");
+    assert.ok(sched[i].start <= dur, "within duration");
+  }
+});
+
+test("scheduleKeyframes handles single + empty keyframe sets", () => {
+  assert.deepEqual(scheduleKeyframes(0, 9000), []);
+  const one = scheduleKeyframes(1, 9000);
+  assert.equal(one.length, 1);
+  assert.equal(one[0].start, 0);
+});

--- a/mother-not-metaphor/tests/unit/poem.test.mjs
+++ b/mother-not-metaphor/tests/unit/poem.test.mjs
@@ -1,0 +1,85 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const poem = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, "../../data/poem.json"), "utf8"),
+);
+
+const LANGS = ["EN", "FR", "AR", "AR-Levantine", "PT-BR"];
+const LAYOUTS = ["L1", "L2", "L3", "L4", "L5"];
+
+test("five moments, in language order", () => {
+  assert.equal(poem.moments.length, 5);
+  assert.deepEqual(
+    poem.moments.map((m) => m.lang),
+    LANGS,
+  );
+});
+
+test("each moment uses a distinct, valid layout (all five used)", () => {
+  const used = poem.moments.map((m) => m.layout);
+  for (const l of used) assert.ok(LAYOUTS.includes(l), `unknown layout ${l}`);
+  assert.equal(new Set(used).size, 5, "layouts are distinct");
+});
+
+test("original text matches the canonical poem openings", () => {
+  const byLang = Object.fromEntries(poem.moments.map((m) => [m.lang, m]));
+  assert.match(
+    byLang.EN.original,
+    /^Mother, there's an ocean, a sea, and a war/,
+  );
+  assert.match(byLang.FR.original, /^Ma mère l'absence de tes côtes/);
+  assert.match(byLang.AR.original, /^Oummi dam3i salibon/);
+  assert.match(byLang["AR-Levantine"].original, /^Mama wa3adtik 2erja3/);
+  assert.match(byLang["PT-BR"].original, /^mas mama preciso/);
+});
+
+test("non-English moments carry an English translation; EN does not", () => {
+  for (const m of poem.moments) {
+    if (m.lang === "EN") assert.equal(m.english, null);
+    else
+      assert.ok(m.english && m.english.length > 10, `${m.lang} needs english`);
+  }
+});
+
+test("palette has the De Stijl set as #rrggbb", () => {
+  for (const key of ["paper", "ink", "blue", "sky", "red", "amber", "green"]) {
+    assert.match(poem.palette[key], /^#[0-9a-f]{6}$/, `palette.${key}`);
+  }
+});
+
+test("every keyframe cell is well-formed and uses a palette color", () => {
+  const paletteKeys = new Set(Object.keys(poem.palette));
+  for (const m of poem.moments) {
+    const kfs = m.illustration.keyframes;
+    assert.ok(Array.isArray(kfs) && kfs.length >= 1, `${m.id} has keyframes`);
+    // within a moment, all keyframes share the same cell count (index-aligned morph)
+    const n = kfs[0].length;
+    for (const kf of kfs) {
+      assert.equal(kf.length, n, `${m.id} keyframes share cell count`);
+      for (const c of kf) {
+        for (const k of ["x", "y", "w", "h"]) {
+          assert.equal(typeof c[k], "number", `${m.id} cell.${k} numeric`);
+          assert.ok(c[k] >= 0 && c[k] <= 100, `${m.id} cell.${k} in viewBox`);
+        }
+        assert.ok(
+          paletteKeys.has(c.fill),
+          `${m.id} fill '${c.fill}' in palette`,
+        );
+        if (c.o != null)
+          assert.ok(c.o >= 0 && c.o <= 1, `${m.id} opacity 0..1`);
+      }
+    }
+  }
+});
+
+test("pacing config is sane", () => {
+  const p = poem.pacing;
+  assert.ok(p.msPerChar > 0);
+  assert.ok(p.minMomentMs > 0 && p.maxMomentMs > p.minMomentMs);
+  assert.ok(p.morphMs > 0 && p.morphMs < p.minMomentMs);
+});


### PR DESCRIPTION
A new mobile-native generative poem at **oulipo.xyz/mother-not-metaphor**, featured on the Kitchen Lab landing.

Five moments / five tongues for one mother (EN / FR / AR-romanized / AR-Levantine / PT-BR). Each moment is a **layout** of three components:
- **camera** - the performer (viewer's live camera)
- **words** - the line revealed like live transcription, with an English translation beneath non-English lines
- **illustration** - a flat-geometric De Stijl composition that morphs, paced to speaking speed

Built as a **reusable poem engine**: the whole piece is `data/poem.json` driven by small modules, so future poems are just new JSON + keyframes (see the README).

## Decisions
- **Hybrid input** - a stable change in the performer's hand shape (MediaPipe Hand Landmarker) advances moments; timed auto-play fallback when there's no camera (e.g. Instagram in-app browser).
- **Scripted typewriter** words - deterministic, offline, original text verbatim.
- **MediaPipe from CDN** - this piece is not fully offline; `verify-purity.mjs` was relaxed to allowlist *only* the MediaPipe model + runtime while still blocking all analytics/trackers.

## How the morph works
Every illustration frame is a set of rectangles; transitions interpolate geometry linearly and **color through OKLab** (blue→red stays vivid, never muddy grey), with cells growing from / collapsing to a point when counts differ. Layout changes use FLIP via the Web Animations API.

## Tests
`npm test` green: **29 unit** (color/morph/pacing/gestures/data) + **html-validate** + **purity** + **18 e2e** (mobile / desktop / reduced-motion). All five layouts + illustrations verified in-browser.

## Integration
- Featured card added to root `index.html` (first of 3) with a De Stijl SVG thumbnail.
- No `vercel.json` change needed (served statically from the folder).
- Added a `mother-not-metaphor` dev-server entry to `.claude/launch.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)