### PR TITLE
mother-patina: hidden console prayer

### DIFF
--- a/mother-patina/chat.js
+++ b/mother-patina/chat.js
@@ -73,6 +73,7 @@ async function boot() {
   if (onLock) {
     setupLock();
     window.__mp.done = true;
+    printPrayer(); // the prayer is hidden in the console even on the landing
     return;
   }
 
@@ -83,6 +84,7 @@ async function boot() {
   DATA = await (await fetch("data/screens.json")).json();
   SCREEN = DATA.screens.find((s) => s.screen === screenNum) || DATA.screens[0];
   PRAYER_TEXT = await loadPrayer(DATA.prayer);
+  printPrayer();
 
   setContact(SCREEN);
   addDateSeparator(screenNum);
@@ -118,6 +120,17 @@ async function loadPrayer(path) {
     return text.trim() ? text : FALLBACK_PRAYER;
   } catch {
     return FALLBACK_PRAYER;
+  }
+}
+
+// hidden: the saved prayer also prints, whole, to the browser console - the same
+// text the reader can save - for anyone who thinks to open it. No hint in the UI.
+async function printPrayer() {
+  try {
+    const text = PRAYER_TEXT || (await loadPrayer("data/prayer.txt"));
+    if (text && text.trim()) console.log("\n" + text + "\n");
+  } catch {
+    /* the prayer is a gift in the console, never a requirement */
   }
 }
 

--- a/mother-patina/tests/e2e/chat.spec.mjs
+++ b/mother-patina/tests/e2e/chat.spec.mjs
@@ -275,6 +275,24 @@ test.describe("mother-patina", () => {
     await expect(page.locator(".reaction")).toHaveText("😂");
   });
 
+  test("the whole prayer is hidden in the browser console (no UI hint)", async ({
+    page,
+  }) => {
+    const logs = [];
+    page.on("console", (m) => logs.push(m.text()));
+    await page.goto("/?screen=5&fast=1");
+    await page.waitForFunction(() => window.__mp && window.__mp.done, {
+      timeout: 10000,
+    });
+    await page.waitForTimeout(150);
+    const joined = logs.join("\n");
+    expect(joined).toContain("When my family forwards Mary"); // the poem
+    expect(joined).toContain("to say I love you.");
+    expect(joined).toContain("✠"); // the ASCII cathedral apex
+    // and nothing in the visible page announces it
+    await expect(page.locator("body")).not.toContainText("console");
+  });
+
   test("the forward button carries a per-screen accessible name (not a static 'continue')", async ({
     page,
   }) => {


### PR DESCRIPTION
Adds a quiet easter egg: the whole saved prayer also prints to the browser console.

## What changed
- A new `printPrayer()` in `chat.js` `console.log`s the full `prayer.txt` (the ASCII Gothic cathedral + poem) on the lock landing and on every chat screen - the same text the reader can "save the prayer" to download, now waiting in the console for anyone who opens devtools.
- **No UI change** - no hint, no label. It reuses the already-loaded `PRAYER_TEXT` (fetches it on the lock screen) and is fully guarded so it never blocks or breaks the piece.

## Verification
14 unit + 51 e2e (adds a console-capture test asserting the cathedral prints, plus that nothing in the page announces it) + lint + purity - **all green**. Confirmed the console shows the full cathedral on both lock and chat screens, with no other console noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)