### PR TITLE
mother-patina: hold the typing dots longer at three high-stakes lines

### DIFF
--- a/mother-patina/chat.js
+++ b/mother-patina/chat.js
@@ -610,7 +610,9 @@ function readDelay(m) {
 }
 function typingDelay(m) {
   if (fast) return 6;
-  return clamp(360 + words(m) * 58, 560, 1800);
+  const base = clamp(360 + words(m) * 58, 560, 1800);
+  // a few high-stakes lines hold the typing dots ~50% longer, so the weight lands.
+  return m.weight ? Math.round(base * 1.5) : base;
 }
 function formatTime(d) {
   let h = d.getHours();

--- a/mother-patina/data/screens.json
+++ b/mother-patina/data/screens.json
@@ -1,5 +1,5 @@
 {
-  "_note": "mother-patina. ONE Virgin Mary image (assets/mary.jpg, text-free) forwarded through the family - each screen is a chat with a DIFFERENT relative (contact + avatar + app), and the image pixelizes one step more each screen (gen 0..4) until it is barely recognizable. app = which messenger this screen imitates (whatsapp | imessage | telegram). avatar is the contact's profile picture (the mother's IS the Virgin Mary). The clean Arabic prayer line is laid over the image AND appears as the first chat bubble (from whoever sent the image). from: a = the reader (right/sent), b = the other person (left/incoming). kind: image | translit | text. reaction: a WhatsApp-style emoji that pops onto that bubble after a beat. forward: how the next screen arrives. prayer: the decorated text saved to the reader's device.",
+  "_note": "mother-patina. ONE Virgin Mary image (assets/mary.jpg, text-free) forwarded through the family - each screen is a chat with a DIFFERENT relative (contact + avatar + app), and the image pixelizes one step more each screen (gen 0..4) until it is barely recognizable. app = which messenger this screen imitates (whatsapp | imessage | telegram). avatar is the contact's profile picture (the mother's IS the Virgin Mary). The clean Arabic prayer line is laid over the image AND appears as the first chat bubble (from whoever sent the image). from: a = the reader (right/sent), b = the other person (left/incoming). kind: image | translit | text. reaction: a WhatsApp-style emoji that pops onto that bubble after a beat. weight: true on a few high-stakes incoming (b) lines holds the typing dots ~50% longer so the weight lands. forward: how the next screen arrives. prayer: the decorated text saved to the reader's device.",
   "image": "assets/mary.jpg",
   "prayer": "data/prayer.txt",
   "screens": [
@@ -182,7 +182,8 @@
         {
           "from": "b",
           "kind": "text",
-          "text": "It must be hard to raise a child who straps his body to a rocket bound to kingdom come."
+          "text": "It must be hard to raise a child who straps his body to a rocket bound to kingdom come.",
+          "weight": true
         },
         { "from": "a", "kind": "text", "text": "lol" },
         {
@@ -340,14 +341,20 @@
           "kind": "text",
           "text": "biology humming the womb's song"
         },
-        { "from": "b", "kind": "text", "text": "I tried to call you" },
+        {
+          "from": "b",
+          "kind": "text",
+          "text": "I tried to call you",
+          "weight": true
+        },
         { "from": "a", "kind": "text", "text": "I missed you" },
         { "from": "a", "kind": "text", "text": "I miss you", "reaction": "❤️" },
         {
           "from": "b",
           "kind": "text",
           "text": "habibi. Me more.",
-          "reaction": "❤️"
+          "reaction": "❤️",
+          "weight": true
         }
       ]
     }

--- a/mother-patina/tests/unit/screens.test.mjs
+++ b/mother-patina/tests/unit/screens.test.mjs
@@ -132,6 +132,29 @@ test("the emoji reactions land on the right messages", () => {
   assert.equal(total, 5);
 });
 
+test("exactly three high-stakes incoming lines carry extra typing weight", () => {
+  const weighted = [];
+  data.screens.forEach((s, i) =>
+    s.messages.forEach((m) => {
+      if (m.weight)
+        weighted.push({ screen: i + 1, from: m.from, text: m.text });
+    }),
+  );
+  assert.equal(weighted.length, 3, "exactly three weighted moments");
+  // weight only makes sense on incoming (b) lines - those are the ones that show typing dots
+  for (const w of weighted) {
+    assert.equal(
+      w.from,
+      "b",
+      `weighted line on screen ${w.screen} must be incoming`,
+    );
+  }
+  const texts = weighted.map((w) => w.text);
+  assert.ok(texts.some((t) => t.includes("It must be hard to raise a child")));
+  assert.ok(texts.includes("I tried to call you"));
+  assert.ok(texts.includes("habibi. Me more."));
+});
+
 test("every message has a valid from + kind", () => {
   const FROMS = new Set(["a", "b", "system"]);
   const KINDS = new Set(["image", "translit", "text"]);


### PR DESCRIPTION
A small, felt thing: the three-dots typing indicator now hangs ~50% longer at three moments where the stakes are highest, so the weight lands.

## The three moments (incoming lines, where the typing dots show)
1. **Sister, screen 3** — "It must be hard to raise a child who straps his body to a rocket bound to kingdom come." (a mother loving a son doomed to die — the thematic gut)
2. **Mother, screen 5** — "I tried to call you" (the unanswered call across the distance)
3. **Mother, screen 5** — "habibi. Me more." (the final, almost-direct "I love you, more")

## How
A `weight: true` flag on those three messages; `typingDelay()` multiplies the dots' duration by 1.5 for them. The `fast=1` test path is untouched, so nothing else changes.

## Verification
Measured real (non-fast) durations: "I tried to call you" **977ms** vs ~650ms baseline; "habibi. Me more." **841ms** vs ~560ms — both ~1.5×. 15 unit (adds a check that exactly three incoming lines carry weight) + 51 e2e + lint + purity — **all green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)