### PR TITLE
mother-patina: revise the saved poem's middle lines

### DIFF
--- a/mother-patina/chat.js
+++ b/mother-patina/chat.js
@@ -57,7 +57,7 @@ const PLACEHOLDER = {
 };
 // if the decorated prayer file can't be read, the artifact still holds the poem.
 const FALLBACK_PRAYER =
-  "When my family forwards Mary\nThey are saying something\nThey don't know what to say but\nMy son, my daughter, my niece, my love\nWe are aging and this faith\nis the buoy we know best.\nThese worn images are how we learned\nto say I love you.\n";
+  "When my family forwards Mary\nThey are saying\nThey don't know what to say\nbut son, daughter, niece, love\nWe are aging and this faith\nis the buoy we know best.\nThese worn images are how we learned\nto say I love you.\n";
 
 window.__mp = { screen: screenNum, lock: onLock, done: false };
 

--- a/mother-patina/data/prayer.txt
+++ b/mother-patina/data/prayer.txt
@@ -18,9 +18,9 @@
   ║───────────────────────────────────────────────║
   ║                                               ║
   ║   When my family forwards Mary                ║
-  ║   They are saying something                   ║
-  ║   They don't know what to say but             ║
-  ║   My son, my daughter, my niece, my love      ║
+  ║   They are saying                             ║
+  ║   They don't know what to say                 ║
+  ║   but son, daughter, niece, love              ║
   ║   We are aging and this faith                 ║
   ║   is the buoy we know best.                   ║
   ║   These worn images are how we learned        ║

--- a/mother-patina/tests/unit/screens.test.mjs
+++ b/mother-patina/tests/unit/screens.test.mjs
@@ -200,8 +200,20 @@ test("the saved prayer is a grandiose ASCII cathedral wrapped around the poem", 
     "the poem opens inside the nave",
   );
   assert.ok(txt.includes("to say I love you."), "the poem closes the nave");
-  // the dropped framing is gone
-  for (const gone of ["AVE MARIA", "a prayer forwarded", "the ask"]) {
+  // the revised middle lines (the "but" leads the address; no possessives)
+  assert.ok(
+    txt.includes("but son, daughter, niece, love"),
+    "the revised address line",
+  );
+  // the dropped framing + the pre-revision phrasings are gone
+  for (const gone of [
+    "AVE MARIA",
+    "a prayer forwarded",
+    "the ask",
+    "They are saying something",
+    "My son, my daughter, my niece, my love",
+    "what to say but",
+  ]) {
     assert.ok(!new RegExp(gone, "i").test(txt), `"${gone}" was dropped`);
   }
 });
@@ -214,8 +226,13 @@ test("the in-code fallback prayer matches the decorated file's poem (no drift)",
   assert.ok(txt.includes("to say I love you."), "prayer.txt keeps the period");
   const fb = js.match(/FALLBACK_PRAYER\s*=\s*"([^]*?)";/);
   assert.ok(fb, "FALLBACK_PRAYER literal found in chat.js");
-  for (const line of ["When my family forwards Mary", "to say I love you."]) {
+  for (const line of [
+    "When my family forwards Mary",
+    "but son, daughter, niece, love",
+    "to say I love you.",
+  ]) {
     assert.ok(fb[1].includes(line), `FALLBACK_PRAYER keeps "${line}"`);
+    assert.ok(txt.includes(line), `prayer.txt keeps "${line}"`);
   }
 });
 


### PR DESCRIPTION
A small text fix to the saved `mother-patina.txt` (the ASCII cathedral) and its in-code fallback:

- `They are saying something` → `They are saying`
- `They don't know what to say but` → `They don't know what to say`
- `My son, my daughter, my niece, my love` → `but son, daughter, niece, love`

The "but" now leads the address and the possessives are dropped. Cathedral nave alignment preserved (every framed row stays 51 cells); `FALLBACK_PRAYER` kept in sync; unit tests lock the new line and reject the old phrasings.

**Also resolves the stuck deploy:** PR #45 (typing-weight) merged to `main` but Vercel never fired a production deploy for it. This new `main` commit re-triggers the production build, so the typing-weight ships alongside this fix.

## Verification
15 unit + 51 e2e (mobile / desktop / reduced-motion) + lint + purity - **all green**. Re-rendered the cathedral to confirm the revised poem reads cleanly and stays aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)